### PR TITLE
Disable `belongs_to` default validation (#196)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,7 @@ module LetMeKnowWhen
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.active_record.belongs_to_required_by_default = false
     config.action_view.form_with_generates_remote_forms = false
 
     config.autoload_paths << Rails.root.join("app/models/nulls")


### PR DESCRIPTION
This check can cause N+1 queries when validating multiple records.
Instead we can validate the presence of a foreign key, rather than the
actual record. As long as there is a foreign key constraint in the
database it will end up being just as good without the performance
implications.