### PR TITLE
Raise on unpermitted params in dev/test mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,8 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,6 +26,8 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
+  config.action_controller.action_on_unpermitted_parameters = :raise
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 


### PR DESCRIPTION
Rather than silently swallowing errors, it'll help to have these fail
loudly.