### PR TITLE
Only load bundler audit task in dev/test modes (#221)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,7 @@ require_relative "config/application"
 
 Rails.application.load_tasks
 
-require "bundler/audit/task"
-Bundler::Audit::Task.new
+if Rails.env.development? || Rails.env.test?
+  require "bundler/audit/task"
+  Bundler::Audit::Task.new
+end


### PR DESCRIPTION
This broke a production deploy because we've only got it in the dev/test
group in our Gemfile.