### PR TITLE
Github: set up Github integration

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+# override these to actual credentials in `.env.test.local`
+GITHUB_EMAIL=test@notice.zone
+GITHUB_PASSWORD=whocaresthiswon'tbeused
+GITHUB_CLIENT_ID=trash
+GITHUB_CLIENT_SECRET=alsotrash

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ spec/examples.txt
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.env.test.local

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,15 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "2.6.3"
 
+# needs to be included before any other gems that use environment variables
+gem "dotenv-rails", groups: [:development, :test]
+
 gem "rails", "~> 6.0.2"
 
 gem "bcrypt"
 gem "bootsnap", require: false
 gem "haml-rails"
+gem "octokit"
 gem "pg"
 gem "pry-rails"
 gem "puma"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,10 +93,16 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     erubis (2.7.0)
     faker (2.11.0)
       i18n (>= 1.6, < 2)
+    faraday (1.0.0)
+      multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
     formatador (0.2.5)
     globalid (0.4.2)
@@ -171,6 +177,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.3)
+    multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
     nenv (0.3.0)
@@ -182,6 +189,9 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     oauth (0.5.4)
+    octokit (4.16.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.19.1)
     parser (2.7.1.0)
       ast (~> 2.4.0)
@@ -300,6 +310,9 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -388,6 +401,7 @@ DEPENDENCIES
   capybara
   capybara-screenshot
   capybara_discoball
+  dotenv-rails
   faker
   guard
   guard-haml_lint
@@ -396,6 +410,7 @@ DEPENDENCIES
   haml-rails
   haml_lint
   listen
+  octokit
   pg
   pry-byebug
   pry-rails

--- a/app/controllers/github_checks_controller.rb
+++ b/app/controllers/github_checks_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class GithubChecksController < ApplicationController
+  def new
+    render(locals: { check: check, integration: integration })
+  end
+
+  def create
+    check.save!
+
+    redirect_to(checks_path)
+  end
+
+  private
+
+  def check
+    Check::Github::UserHasAssignedPullRequests.new(check_params)
+  end
+
+  def integration
+    @integration ||=
+      current_user.integrations.find(params.fetch(:github_integration_id))
+  end
+
+  def check_params
+    check_params =
+      if params.key?(:check)
+        params.require(:check).permit(:name)
+      else
+        {}
+      end
+    check_params.merge(user: current_user, integration: integration)
+  end
+end

--- a/app/controllers/github_integrations_controller.rb
+++ b/app/controllers/github_integrations_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class GithubIntegrationsController < ApplicationController
+  def new
+    render(locals: { github_authorize_url: github_authorize_url })
+  end
+
+  def create
+    if session.delete(:github_state) != params[:state]
+      raise ActionController::RoutingError, "Not Found"
+    end
+
+    integration = Integration::Github.create!(integration_params)
+
+    redirect_to(new_github_integration_check_path(integration))
+  end
+
+  private
+
+  def integration_params
+    { user: current_user, code: params.fetch(:code) }
+  end
+
+  def github_authorize_url
+    session[:github_state] = SecureRandom.hex(16)
+    Integration::Github.authorize_url(state: session[:github_state])
+  end
+end

--- a/app/controllers/trello_integrations_controller.rb
+++ b/app/controllers/trello_integrations_controller.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "trello"
-
 class TrelloIntegrationsController < ApplicationController
   def new
     render(locals: { trello_authorize_url: trello_authorize_url })

--- a/app/models/check/github/user_has_assigned_pull_requests.rb
+++ b/app/models/check/github/user_has_assigned_pull_requests.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class Check < ApplicationRecord
+  module Github
+    class UserHasAssignedPullRequests < Check
+      delegate :pull_requests, to: :integration
+
+      STEPS = ["name"].freeze
+
+      def next_step
+        STEPS.find { |step| public_send(step).nil? }
+      end
+
+      def message
+        "#{pull_requests.count} assigned pull requests"
+      end
+
+      def url
+        "#{integration.api_endpoint}pulls/assigned"
+      end
+    end
+  end
+end

--- a/app/models/integration/github.rb
+++ b/app/models/integration/github.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+class Integration < ApplicationRecord
+  CLIENT_ID = ENV.fetch("GITHUB_CLIENT_ID")
+  CLIENT_SECRET = ENV.fetch("GITHUB_CLIENT_SECRET")
+
+  class Github < Integration
+    class << self
+      attr_writer :implementation
+
+      def implementation
+        @implementation ||= ::Octokit
+      end
+
+      def authorize_url(state:)
+        client.authorize_url(CLIENT_ID, scope: "repo", state: state)
+      end
+
+      def client
+        @client ||= implementation::Client.new(
+          client_id: CLIENT_ID,
+          client_secret: CLIENT_SECRET,
+        )
+      end
+    end
+
+    validates :access_token, presence: true
+    store_accessor :data, :access_token
+    delegate :implementation, to: :class
+    delegate :api_endpoint, to: :client
+
+    def code=(code)
+      data = client.exchange_code_for_token(code)
+      self.access_token = data.access_token
+    end
+
+    def pull_requests
+      client.issues.select(&:pull_request)
+    end
+
+    private
+
+    def client
+      @client ||= implementation::Client.new(
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        access_token: access_token,
+      )
+    end
+  end
+end

--- a/app/views/checks/new.html.haml
+++ b/app/views/checks/new.html.haml
@@ -1,3 +1,4 @@
 %h2 Pick an integration
 
 = link_to("Trello", new_trello_integration_path)
+= link_to("GitHub", new_github_integration_path)

--- a/app/views/github_checks/_name.html.haml
+++ b/app/views/github_checks/_name.html.haml
@@ -1,0 +1,8 @@
+%h2 Name your check
+
+- submit_path = github_integration_checks_path(integration)
+= form_with(model: check, url: submit_path) do |form|
+  = form.label(:name)
+  = form.text_field(:name)
+
+  = form.submit("Done")

--- a/app/views/github_checks/new.html.haml
+++ b/app/views/github_checks/new.html.haml
@@ -1,0 +1,1 @@
+= render(check.next_step, check: check, integration: integration)

--- a/app/views/github_integrations/new.html.haml
+++ b/app/views/github_integrations/new.html.haml
@@ -1,0 +1,3 @@
+First time GitHub integration
+
+= link_to("Authenticate with GitHub", github_authorize_url)

--- a/config/initializers/dotenv.rb
+++ b/config/initializers/dotenv.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+if Rails.env.development? || Rails.env.test?
+  Dotenv.require_keys("GITHUB_EMAIL", "GITHUB_PASSWORD")
+end

--- a/config/initializers/octokit.rb
+++ b/config/initializers/octokit.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Octokit.configure do |config|
+  config.connection_options = { request: { open_timeout: 5, timeout: 5 } }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,5 +14,10 @@ Rails.application.routes.draw do
     resources :checks, only: [:new, :create], controller: "trello_checks"
   end
 
+  resources :github_integrations, only: [:new] do
+    resources :checks, only: [:new, :create], controller: "github_checks"
+  end
+
   get "/trello_integrations/create", to: "trello_integrations#create"
+  get "/github_integrations/create", to: "github_integrations#create"
 end

--- a/spec/controllers/github_integrations_controller_spec.rb
+++ b/spec/controllers/github_integrations_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GithubIntegrationsController do
+  describe "#create" do
+    user_params = {
+      email: "demo@exampoo.com",
+      password: "super-secure",
+      password_confirmation: "super-secure",
+    }
+
+    it "raises an error when :state parameter does not match" do
+      session[:user_id] = User.create!(user_params).id
+      session[:github_state] = "baa"
+
+      expect { get(:create, params: { state: "boo" }) }
+        .to raise_error(ActionController::RoutingError, "Not Found")
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe User, type: :model do
     email: "demo@exampoo.com",
     password: "super-secure",
     password_confirmation: "super-secure",
-  }
+  }.freeze
 
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to have_secure_password }

--- a/spec/support/fake_api/github/implementation.rb
+++ b/spec/support/fake_api/github/implementation.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module FakeApi
+  module Github
+    class Implementation
+      class << self
+        attr_writer :endpoint_url
+
+        def endpoint_url
+          @endpoint_url || (raise ArgumentError, "missing endpoint_url")
+        end
+      end
+
+      class Issue
+        attr_accessor :pull_request
+
+        def initialize(pull_request:)
+          self.pull_request = pull_request
+        end
+      end
+
+      class Client
+        def initialize(client_id:, client_secret:, access_token: nil); end
+
+        # https://github.com/login/oauth/authorize?client_id=b196fb782d84648a9ff2&scope=repo
+        def authorize_url(_client_id, state:, **)
+          "#{Implementation.endpoint_url}/login/oauth/authorize?state=#{state}"
+        end
+
+        def exchange_code_for_token(_code)
+          OpenStruct.new(access_token: "some-auth-token")
+        end
+
+        def issues
+          [
+            Issue.new(pull_request: true),
+            Issue.new(pull_request: true),
+            Issue.new(pull_request: false),
+          ]
+        end
+
+        def api_endpoint
+          "/fake_github_url"
+        end
+      end
+    end
+  end
+end

--- a/spec/support/fake_api/github/server.rb
+++ b/spec/support/fake_api/github/server.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "sinatra/base"
+
+module FakeApi
+  module Github
+    class Server < Sinatra::Base
+      enable(:sessions)
+      class << self
+        attr_accessor :return_url
+      end
+
+      get("/login/oauth/authorize") do
+        session["state"] = params["state"]
+        <<-HTML
+          <form action="/session" accept-charset="UTF-8" method="post">
+            <div class="auth-form-body mt-3">
+              <label for="login_field">Username or email address</label>
+              <input type="text" name="login" id="login_field" />
+
+              <label for="password">Password</label>
+              <input type="password" name="password" id="password" />
+
+              <input type="submit" name="commit" value="Sign in" />
+            </div>
+          </form>
+        HTML
+      end
+
+      post("/session") do
+        state = session["state"]
+        redirect("#{self.class.return_url}?code=some_code&state=#{state}")
+      end
+      run! if app_file == $PROGRAM_NAME
+    end
+  end
+end

--- a/spec/support/fake_apis_rails.rb
+++ b/spec/support/fake_apis_rails.rb
@@ -2,6 +2,8 @@
 
 if fake_apis?
   require "capybara_discoball"
+  require_relative "fake_api/github/implementation"
+  require_relative "fake_api/github/server"
   require_relative "fake_api/trello/implementation"
   require_relative "fake_api/trello/server"
 
@@ -9,9 +11,23 @@ if fake_apis?
     FakeApi::Trello::Implementation.endpoint_url = server.url
   end
 
-  RSpec.configuration.before do
+  Capybara::Discoball.spin(FakeApi::Github::Server) do |server|
+    FakeApi::Github::Implementation.endpoint_url = server.url
+  end
+
+  RSpec.configuration.before(js: true) do
+    server = Capybara.current_session.server
+    FakeApi::Github::Server.return_url =
+      Rails.application.routes.url_helpers.github_integrations_create_url(
+        host: server.host,
+        port: server.port,
+      )
+    Integration::Github.implementation = FakeApi::Github::Implementation
     Integration::Trello.implementation = FakeApi::Trello::Implementation
   end
 else
+  # For integrations like GitHub we need a URL with a constant server port to
+  # be configured via their web interface
+  Capybara.server_port = 38_091
   Capybara.default_max_wait_time = 10
 end

--- a/spec/system/github_integration_spec.rb
+++ b/spec/system/github_integration_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "GitHub integration", type: :system, js: true do
+  user_params = {
+    email: "demo@lmkw.io",
+    password: "secret",
+    password_confirmation: "secret",
+  }
+
+  def github_params
+    { email: ENV.fetch("GITHUB_EMAIL"), password: ENV.fetch("GITHUB_PASSWORD") }
+  end
+
+  def sign_in(user)
+    visit("/")
+
+    click_link("Log In")
+
+    expect(page).to have_text("Log in to LetMeKnowWhen")
+
+    fill_in("Email", with: user.email)
+    fill_in("Password", with: user.password)
+
+    click_button("Log In")
+  end
+
+  def start_new_check
+    expect(page).to have_heading("Checks")
+    click_link("+ New Check")
+
+    expect(page).to have_text("Pick an integration")
+  end
+
+  def authenticate_with_github
+    click_link("GitHub")
+
+    expect(page).to have_text("First time GitHub integration")
+
+    click_link("Authenticate with GitHub")
+    fill_in("Username or email", with: github_params[:email])
+    fill_in("Password", with: github_params[:password])
+    click_button("Sign in")
+    # click_button("Authorize")
+  end
+
+  def create_github_check(name:)
+    input_name(name)
+
+    expect(page).to have_heading("Checks")
+  end
+
+  def input_name(name)
+    # wait to allow time to copy/paste email verification code if necessary
+    expect(page).to have_text("Name your check", wait: 10.minutes)
+    fill_in("Name", with: name)
+    click_button("Done")
+  end
+
+  it "allows a user to configure a Trello integration" do
+    sign_in(User.create!(user_params))
+    start_new_check
+
+    authenticate_with_github
+    create_github_check(name: "Pulls for Me")
+
+    expect(page).to have_check("Pulls for Me", text: "2 assigned pull requests")
+  end
+end

--- a/spec/system/trello_integration_spec.rb
+++ b/spec/system/trello_integration_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe "Trello integration", type: :system, js: true do
 
     click_link("Authenticate with Trello")
     click_link("Log in")
-    fill_in("Email", with: trello_params[:email])
-    fill_in("Password", with: trello_params[:password])
+    fill_in("user", with: trello_params[:email])
+    fill_in("password", with: trello_params[:password])
     click_button("Log in")
     click_button("Allow")
   end


### PR DESCRIPTION
I didn't use the `api_endpoint` option Octokit provides because this is
more in line with the way the Trello integration is set up.