### PR TITLE
Ignore development dotenv file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ spec/examples.txt
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.env.development.local
 .env.test.local


### PR DESCRIPTION
Can't boot the dev environment without this.