### PR TITLE
Fix deprecation warnings

### DIFF
--- a/app/jobs/callable_job.rb
+++ b/app/jobs/callable_job.rb
@@ -3,7 +3,7 @@
 require_relative "./application_job"
 
 class CallableJob < ApplicationJob
-  def perform(callable_name, *args)
-    callable_name.constantize.call(*args)
+  def perform(callable_name, *args, **kwargs)
+    callable_name.constantize.call(*args, **kwargs)
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -6,8 +6,8 @@ require "capybara-screenshot/rspec"
 require_relative "capybara/rack_test"
 
 Capybara.server = :puma, { Silent: true }
-Capybara.drivers[:chrome] = Capybara.drivers[:selenium_chrome]
-Capybara.drivers[:firefox] = Capybara.drivers[:selenium]
+Capybara.register_driver(:chrome, &Capybara.drivers[:selenium_chrome])
+Capybara.register_driver(:firefox, &Capybara.drivers[:selenium])
 Capybara.save_path = ENV.fetch("CIRCLE_ARTIFACTS", Capybara.save_path)
 
 driver = ENV.fetch("DRIVER").to_sym if ENV.key?("DRIVER")

--- a/spec/support/matchers/have_check.rb
+++ b/spec/support/matchers/have_check.rb
@@ -12,11 +12,11 @@ module Matchers
         self.memoized_results = Hash.new { |hash, key| hash[key] = {} }
       end
 
-      def method_missing(method_name, *args)
+      def method_missing(method_name, *args, **kwargs)
         super unless element.respond_to?(method_name)
 
-        memoized_results[method_name].fetch(args) do
-          memoize(element.public_send(method_name, *args))
+        memoized_results[method_name].fetch([args, kwargs]) do
+          memoize(element.public_send(method_name, *args, **kwargs))
         end
       end
 


### PR DESCRIPTION
Warnings about keyword args in Ruby 2.7 and warnings from Capybara about
how to set drivers.
