### PR TITLE
Introduce CheckCount model

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   DefaultFormatter: fuubar
   DisplayCopNames: true
   EnabledByDefault: true
-  Exclude: [node_modules/**/*, vendor/**/*]
+  Exclude: [node_modules/**/*, vendor/**/*, db/schema.rb]
 
 ################################################################################
 #
@@ -21,7 +21,6 @@ Style/TrailingCommaInBlockArgs: { Enabled: false }
 Layout/LineLength:
   Exclude:
     - 'config/**/*'
-    - 'db/schema.rb'
   AutoCorrect: true
 Layout/TrailingEmptyLines: { Enabled: false }
 Metrics/BlockLength:
@@ -29,7 +28,6 @@ Metrics/BlockLength:
     - describe
   Exclude:
     - Guardfile
-    - db/schema.rb
 Rails/FilePath: { EnforcedStyle: slashes }
 RSpec/MultipleExpectations:
   Exclude:
@@ -81,7 +79,6 @@ Style/MethodCallWithArgsParentheses:
     - Guardfile
     - Gemfile
 Style/MixinUsage: { Exclude: ['bin/**/*'] }
-Style/NumericLiterals: { Exclude: [db/schema.rb] }
 Style/StringLiterals: { EnforcedStyle: double_quotes }
 Style/StringLiteralsInInterpolation: { EnforcedStyle: double_quotes }
 Style/SymbolArray: { EnforcedStyle: brackets }

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -2,8 +2,15 @@
 
 class ChecksController < ApplicationController
   def index
+    refresh_checks
     render(locals: { checks: current_user.checks })
   end
 
   def new; end
+
+  private
+
+  def refresh_checks
+    current_user.checks.each(&:refresh)
+  end
 end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -3,12 +3,23 @@
 class Check < ApplicationRecord
   belongs_to :user
   belongs_to :integration
+  has_many :counts,
+           class_name: "CheckCount",
+           dependent: :restrict_with_exception
   validates :name, presence: true, uniqueness: { scope: :user_id }
-  validates :user_id, presence: true
+  validates :integration_id, :user_id, presence: true
 
   class << self
     def model_name
       ActiveModel::Name.new(base_class)
     end
   end # class << self
+
+  def refresh
+    raise NotImplementedError
+  end
+
+  def last_value
+    counts.last && counts.last.value
+  end
 end

--- a/app/models/check/github/user_has_assigned_pull_requests.rb
+++ b/app/models/check/github/user_has_assigned_pull_requests.rb
@@ -7,12 +7,16 @@ class Check < ApplicationRecord
 
       STEPS = ["name"].freeze
 
+      def refresh
+        counts.create!(value: pull_requests.count)
+      end
+
       def next_step
         STEPS.find { |step| public_send(step).nil? }
       end
 
       def message
-        "#{pull_requests.count} assigned pull requests"
+        "#{last_value} assigned pull requests"
       end
 
       def url

--- a/app/models/check/trello/list_has_cards.rb
+++ b/app/models/check/trello/list_has_cards.rb
@@ -11,12 +11,16 @@ class Check < ApplicationRecord
 
       STEPS = ["board_id", "list_id", "name"].freeze
 
+      def refresh
+        counts.create!(value: cards.count)
+      end
+
       def next_step
         STEPS.find { |step| public_send(step).nil? }
       end
 
       def message
-        "#{cards.count} cards in #{list.name}"
+        "#{last_value} cards in #{list.name}"
       end
 
       def board

--- a/app/models/check_count.rb
+++ b/app/models/check_count.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CheckCount < ApplicationRecord
+  belongs_to :check
+  validates :check_id, :value, presence: true
+end

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -2,6 +2,6 @@
 
 class Integration < ApplicationRecord
   belongs_to :user
-  validates :user_id, presence: true
+  validates :type, :user_id, presence: true
   validates :type, uniqueness: { scope: :user_id }
 end

--- a/db/migrate/20200412213655_create_check_counts.rb
+++ b/db/migrate/20200412213655_create_check_counts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateCheckCounts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :check_counts do |t|
+      t.references :check, null: false, foreign_key: true
+      t.bigint :value, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,9 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_04_222631) do
+ActiveRecord::Schema.define(version: 2020_04_12_213655) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "check_counts", force: :cascade do |t|
+    t.bigint "check_id", null: false
+    t.bigint "value", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["check_id"], name: "index_check_counts_on_check_id"
+  end
 
   create_table "checks", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -48,6 +55,7 @@ ActiveRecord::Schema.define(version: 2019_10_04_222631) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "check_counts", "checks"
   add_foreign_key "checks", "integrations"
   add_foreign_key "checks", "users"
   add_foreign_key "integrations", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,3 @@
 # frozen_string_literal: true
+
+User.create!(email: "demo@notice.zone", password: "notice")

--- a/spec/models/check_count_spec.rb
+++ b/spec/models/check_count_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe CheckCount, type: :model do
+  it { is_expected.to validate_presence_of(:check_id) }
+  it { is_expected.to validate_presence_of(:value) }
+  it { is_expected.to belong_to(:check) }
+end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Check, type: :model do
+  describe "#refresh" do
+    it "raises a NotImplementedError" do
+      expect { described_class.new.refresh }
+        .to raise_error(NotImplementedError)
+    end
+  end
+end


### PR DESCRIPTION
This introduces a new model where we will be storing check values. This
is to allow us to do the checking bit in the background, rather than
having it happen on every request. In followups, we'll add background
jobs.
