### PR TITLE
Introduce background job to run checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "rails", "~> 6.0.2"
 gem "bcrypt"
 gem "bootsnap", require: false
 gem "haml-rails"
+gem "junk_drawer"
 gem "octokit"
 gem "pg"
 gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.3.1)
+    junk_drawer (1.6.3)
+      ruby2_keywords (~> 0.0.2)
     launchy (2.5.0)
       addressable (~> 2.7)
     listen (3.2.1)
@@ -409,6 +411,7 @@ DEPENDENCIES
   guard-rubocop
   haml-rails
   haml_lint
+  junk_drawer
   listen
   octokit
   pg

--- a/Guardfile
+++ b/Guardfile
@@ -42,7 +42,7 @@ group :everything, halt_on_fail: true do
     watch(%r{(?:.+/)?\.haml-lint\.yml$}) { |m| File.dirname(m[0]) }
   end
 
-  guard :rubocop, all_on_start: false, cli: ["-a", "--display-cop-names"] do
+  guard :rubocop, all_on_start: false, cli: ["-A", "--display-cop-names"] do
     watch(/.+\.rb$/)
     watch(%r{bin/*})
     watch(/Guardfile/)

--- a/app/actions/check/run_all_outdated.rb
+++ b/app/actions/check/run_all_outdated.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Check < ApplicationRecord
+  class RunAllOutdated
+    include JunkDrawer::Callable
+
+    def call
+      Check.last_counted_before(1.hour.ago).find_each(&:refresh)
+    end
+  end
+end

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -2,15 +2,8 @@
 
 class ChecksController < ApplicationController
   def index
-    refresh_checks
     render(locals: { checks: current_user.checks })
   end
 
   def new; end
-
-  private
-
-  def refresh_checks
-    current_user.checks.each(&:refresh)
-  end
 end

--- a/app/controllers/github_checks_controller.rb
+++ b/app/controllers/github_checks_controller.rb
@@ -7,6 +7,7 @@ class GithubChecksController < ApplicationController
 
   def create
     check.save!
+    check.refresh
 
     redirect_to(checks_path)
   end
@@ -14,7 +15,7 @@ class GithubChecksController < ApplicationController
   private
 
   def check
-    Check::Github::UserHasAssignedPullRequests.new(check_params)
+    @check ||= Check::Github::UserHasAssignedPullRequests.new(check_params)
   end
 
   def integration

--- a/app/controllers/trello_checks_controller.rb
+++ b/app/controllers/trello_checks_controller.rb
@@ -7,6 +7,7 @@ class TrelloChecksController < ApplicationController
 
   def create
     check.save!
+    check.refresh
 
     redirect_to(checks_path)
   end
@@ -14,7 +15,7 @@ class TrelloChecksController < ApplicationController
   private
 
   def check
-    Check::Trello::ListHasCards.new(check_params.merge(base_params))
+    @check ||= Check::Trello::ListHasCards.new(check_params.merge(base_params))
   end
 
   def trello_integration

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -8,6 +8,17 @@ class Check < ApplicationRecord
            dependent: :restrict_with_exception
   validates :name, presence: true, uniqueness: { scope: :user_id }
   validates :integration_id, :user_id, presence: true
+  scope(
+    :last_counted_before,
+    lambda { |timestamp|
+      left_joins(:counts)
+          .having(
+            "MAX(check_counts.created_at) < ? OR COUNT(check_counts) = 0",
+            timestamp,
+          )
+          .group("checks.id")
+    },
+  )
 
   class << self
     def model_name

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,8 +13,7 @@ module LetMeKnowWhen
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults(6.0)
 
-    config.active_job.queue_adapter     = :sidekiq
-    config.active_job.queue_name_prefix = "letmeknowwhen_#{Rails.env}"
+    config.active_job.queue_adapter = :sidekiq
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/lib/tasks/job.rake
+++ b/lib/tasks/job.rake
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+namespace(:job) do
+  desc("run the given background job")
+  task(:enqueue, [:callable_name] => :environment) do |_task, args|
+    CallableJob.perform_later(args.fetch(:callable_name))
+  end
+end

--- a/spec/actions/check/run_all_outdated_spec.rb
+++ b/spec/actions/check/run_all_outdated_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Check::RunAllOutdated do
+  it "runs checks that have not been updated in an hour" do
+    check = create_check(counts: [{ created_at: 61.minutes.ago }])
+
+    expect { described_class.call }
+      .to change(check.counts, :count).by(1)
+  end
+
+  it "does not run checks that have been updated in the last hour" do
+    check = create_check(counts: [{ created_at: 59.minutes.ago }])
+
+    expect { described_class.call }
+      .not_to change(check.counts, :count)
+  end
+end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -3,6 +3,33 @@
 require "rails_helper"
 
 RSpec.describe Check, type: :model do
+  it { is_expected.to belong_to(:integration) }
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to have_many(:counts).class_name("CheckCount") }
+  it { is_expected.to validate_presence_of(:user_id) }
+
+  describe ".last_counted_before" do
+    it "returns checks with counts prior to timestamp" do
+      check = create_check(counts: [{ created_at: 1.day.ago }])
+
+      expect(described_class.last_counted_before(1.minute.ago)).to eq([check])
+    end
+
+    it "does not return checks with counts after the timestamp" do
+      create_check(
+        counts: [{ created_at: 5.minutes.ago }, { created_at: 3.days.ago }],
+      )
+
+      expect(described_class.last_counted_before(1.hour.ago)).to eq([])
+    end
+
+    it "returns checks with no counts" do
+      check = create_check
+
+      expect(described_class.last_counted_before(Time.zone.now)).to eq([check])
+    end
+  end
+
   describe "#refresh" do
     it "raises a NotImplementedError" do
       expect { described_class.new.refresh }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,9 +12,11 @@ require "rspec/rails"
 require "sidekiq/testing"
 
 require_relative "support/capybara"
+require_relative "support/factories"
 require_relative "support/fake_apis_rails"
 require_relative "support/mocks"
 require_relative "support/shoulda_matchers"
+require_relative "support/test_models"
 
 begin
   ActiveRecord::Migration.maintain_test_schema!

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Factories
+  def create_check(counts: [])
+    integration = create_integration
+    check = Test::Check.create!(
+      name: "some check",
+      integration: integration,
+      user: integration.user,
+    )
+    counts.each do |count_params|
+      create_count(count_params.merge(check: check))
+    end
+    check
+  end
+
+  def create_count(params)
+    CheckCount.create!({ value: 0 }.merge(params))
+  end
+
+  def create_integration
+    Test::Integration.create!(user: create_user)
+  end
+
+  def create_user
+    User.create!(
+      email: "demo@exampoo.com",
+      password: "super-secure",
+      password_confirmation: "super-secure",
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include(Factories)
+end

--- a/spec/support/test_models.rb
+++ b/spec/support/test_models.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Test
+  class Integration < Integration
+  end
+
+  class Check < Check
+    def refresh
+      counts.create!(value: 53)
+    end
+  end
+end


### PR DESCRIPTION
Rather than refreshing checks on every page visit, we'll instead run
them on an hourly basis.
