### PR TITLE
Bugs: fix url for github checks

### DIFF
--- a/app/models/check/github/user_has_assigned_pull_requests.rb
+++ b/app/models/check/github/user_has_assigned_pull_requests.rb
@@ -20,7 +20,7 @@ class Check < ApplicationRecord
       end
 
       def url
-        "#{integration.api_endpoint}pulls/assigned"
+        "#{integration.web_endpoint}pulls/assigned"
       end
     end
   end

--- a/app/models/integration/github.rb
+++ b/app/models/integration/github.rb
@@ -27,7 +27,7 @@ class Integration < ApplicationRecord
     validates :access_token, presence: true
     store_accessor :data, :access_token
     delegate :implementation, to: :class
-    delegate :api_endpoint, to: :client
+    delegate :web_endpoint, to: :client
 
     def code=(code)
       data = client.exchange_code_for_token(code)

--- a/spec/support/fake_api/github/implementation.rb
+++ b/spec/support/fake_api/github/implementation.rb
@@ -39,7 +39,7 @@ module FakeApi
           ]
         end
 
-        def api_endpoint
+        def web_endpoint
           "/fake_github_url"
         end
       end


### PR DESCRIPTION
It was pointing at `api.github.com` instead of `github.com`. This is the
URL that is presented to the user.
