### PR TITLE
Bugs: don't pass user to account path

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,7 +23,7 @@
       - if current_user.logged_in?
         = current_user.email
         %br
-        = link_to("Account", account_path(current_user))
+        = link_to("Account", account_path)
         = link_to("Log Out", session_path, method: :delete)
       - else
         = link_to("Log In", new_session_path)


### PR DESCRIPTION
We automatically look up the current user when visiting the account
page, so no need to pass the user. Passing the user resulted in the user
id being appended to the URL, e.g. `/account.1`.
