### PR TITLE
Switch Puma port to 3000

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bundle exec puma -C config/puma.rb
+web: bundle exec puma -C config/puma.rb -p 3000
 critical_worker: bundle exec sidekiq -C config/sidekiq_critical.yml -q critical
 default_worker: bundle exec sidekiq -C config/sidekiq_default.yml -q critical -q default
 slow_worker: bundle exec sidekiq -C config/sidekiq_slow.yml -q critical -q default -q slow


### PR DESCRIPTION
A common default for Rails apps. The Puma default is 5000.
