### PR TITLE
Use existing integration when present

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ Style/MethodCallWithArgsParentheses:
     - require
     - require_relative
     - ruby
+    - scope
     - source
     - store_accessor
     - to

--- a/Guardfile
+++ b/Guardfile
@@ -13,8 +13,6 @@ group :everything, halt_on_fail: true do
     dsl = Guard::RSpec::Dsl.new(self)
 
     rspec = dsl.rspec
-    watch(rspec.spec_helper) { rspec.spec_dir }
-    watch(rspec.spec_support) { rspec.spec_dir }
     watch(rspec.spec_files)
 
     ruby = dsl.ruby
@@ -30,11 +28,7 @@ group :everything, halt_on_fail: true do
       ]
     end
 
-    watch(rails.spec_helper)     { rspec.spec_dir }
-    watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
-
-    watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
-    watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+    watch(rails.app_controller) { "#{rspec.spec_dir}/controllers" }
   end
 
   guard :haml_lint, all_on_start: false do

--- a/app/controllers/github_integrations_controller.rb
+++ b/app/controllers/github_integrations_controller.rb
@@ -2,7 +2,12 @@
 
 class GithubIntegrationsController < ApplicationController
   def new
-    render(locals: { github_authorize_url: github_authorize_url })
+    integration = current_user.integrations.github.first
+    if integration
+      redirect_to(new_github_integration_check_path(integration))
+    else
+      render(locals: { github_authorize_url: github_authorize_url })
+    end
   end
 
   def create

--- a/app/controllers/trello_integrations_controller.rb
+++ b/app/controllers/trello_integrations_controller.rb
@@ -2,7 +2,12 @@
 
 class TrelloIntegrationsController < ApplicationController
   def new
-    render(locals: { trello_authorize_url: trello_authorize_url })
+    integration = current_user.integrations.trello.first
+    if integration
+      redirect_to(new_trello_integration_check_path(integration))
+    else
+      render(locals: { trello_authorize_url: trello_authorize_url })
+    end
   end
 
   def create

--- a/app/models/integration.rb
+++ b/app/models/integration.rb
@@ -4,4 +4,7 @@ class Integration < ApplicationRecord
   belongs_to :user
   validates :type, :user_id, presence: true
   validates :type, uniqueness: { scope: :user_id }
+
+  scope :github, -> { where(type: "Integration::Github") }
+  scope :trello, -> { where(type: "Integration::Trello") }
 end

--- a/spec/controllers/github_integrations_controller_spec.rb
+++ b/spec/controllers/github_integrations_controller_spec.rb
@@ -3,6 +3,26 @@
 require "rails_helper"
 
 RSpec.describe GithubIntegrationsController do
+  describe "#new" do
+    it "redirects to the new check page when integration already exists" do
+      integration = create_integration(:github)
+      login_as(integration.user)
+
+      get(:new)
+
+      expected_path = new_github_integration_check_path(integration)
+      expect(response).to redirect_to(expected_path)
+    end
+
+    it "renders the new page when integration does not exist" do
+      login_as(create_user)
+
+      get(:new)
+
+      expect(rendered).to have_link("Authenticate with GitHub")
+    end
+  end
+
   describe "#create" do
     user_params = {
       email: "demo@exampoo.com",

--- a/spec/controllers/trello_integrations_controller_spec.rb
+++ b/spec/controllers/trello_integrations_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TrelloIntegrationsController do
+  describe "#new" do
+    it "redirects to the new check page when integration already exists" do
+      integration = create_integration(:trello)
+      login_as(integration.user)
+
+      get(:new)
+
+      expected_path = new_trello_integration_check_path(integration)
+      expect(response).to redirect_to(expected_path)
+    end
+
+    it "renders the new page when integration does not exist" do
+      login_as(create_user)
+
+      get(:new)
+
+      expect(rendered).to have_link("Authenticate with Trello")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,7 @@ require "sidekiq/testing"
 require_relative "support/capybara"
 require_relative "support/factories"
 require_relative "support/fake_apis_rails"
+require_relative "support/helpers/controller"
 require_relative "support/mocks"
 require_relative "support/shoulda_matchers"
 require_relative "support/test_models"
@@ -35,4 +36,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 
   config.render_views
+
+  config.include(Helpers::Controller, type: :controller)
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -18,8 +18,17 @@ module Factories
     CheckCount.create!({ value: 0 }.merge(params))
   end
 
-  def create_integration
-    Test::Integration.create!(user: create_user)
+  def create_integration(type = :test, user: create_user)
+    case type
+    when :github
+      Integration::Github.create!(user: user, access_token: "foo")
+    when :trello
+      Integration::Trello.create!(user: user, member_token: "foo")
+    when :test
+      Test::Integration.create!(user: user)
+    else
+      raise ArgumentError, "invalid type: #{type}"
+    end
   end
 
   def create_user

--- a/spec/support/helpers/controller.rb
+++ b/spec/support/helpers/controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Helpers
+  module Controller
+    def login_as(user)
+      session[:user_id] = user.id
+    end
+
+    def rendered
+      Capybara.string(response.body)
+    end
+  end
+end


### PR DESCRIPTION
This redirects to the new check page when integration already exists for
the service.
