### PR TITLE
Fix some flaky tests

### DIFF
--- a/app/models/integration/github.rb
+++ b/app/models/integration/github.rb
@@ -6,7 +6,10 @@ class Integration < ApplicationRecord
 
   class Github < Integration
     class << self
-      attr_writer :implementation
+      def implementation=(implementation)
+        @implementation = implementation
+        @client = nil
+      end
 
       def implementation
         @implementation ||= ::Octokit

--- a/spec/models/nulls/null_user_spec.rb
+++ b/spec/models/nulls/null_user_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+rails_require "app/models/nulls/null_user"
+
 RSpec.describe NullUser do
   describe "#authenticate" do
     it "returns false" do

--- a/spec/system/github_integration_spec.rb
+++ b/spec/system/github_integration_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe "GitHub integration", type: :system, js: true do
 
   def input_name(name)
     # wait to allow time to copy/paste email verification code if necessary
-    expect(page).to have_text("Name your check", wait: 10.minutes)
+    wait_time = fake_apis? ? Capybara.default_max_wait_time : 10.minutes
+    expect(page).to have_text("Name your check", wait: wait_time)
     fill_in("Name", with: name)
     click_button("Done")
   end


### PR DESCRIPTION
* Require `null_user` so spec can be run individually/first. It was
  implicitly relying on other tests to load the class first.
* Fix the wait time in `github_integration_spec.rb`. It was waiting 10
  minutes, even when the API was faked.
* Clear out `@client` when we set `@integration`. In the tests it was
  setting the client to the default `Octokit` client, and then later
  faking the API, but the old real client was still stored on the class.
  We needed to clear it out so that it would instead instantiate our
  fake client.
