### PR TITLE
Change the way we boot Rails in dev mode

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bundle exec puma -C config/puma.rb -p 3000
+web: bundle exec rails s -p 3000
 critical_worker: bundle exec sidekiq -C config/sidekiq_critical.yml -q critical
 default_worker: bundle exec sidekiq -C config/sidekiq_default.yml -q critical -q default
 slow_worker: bundle exec sidekiq -C config/sidekiq_slow.yml -q critical -q default -q slow


### PR DESCRIPTION
The logs don't show up in the `foreman` output when we use `puma`
directly. Booting with `rails s` properly shows logs, and it still uses
`puma`.
