### PR TITLE
refresh every 5 minutes

### DIFF
--- a/app/actions/check/run_all_outdated.rb
+++ b/app/actions/check/run_all_outdated.rb
@@ -5,7 +5,7 @@ class Check < ApplicationRecord
     include JunkDrawer::Callable
 
     def call
-      Check.last_counted_before(1.hour.ago).find_each(&:refresh)
+      Check.last_counted_before(5.minutes.ago).find_each(&:refresh)
     end
   end
 end

--- a/app/views/checks/index.html.haml
+++ b/app/views/checks/index.html.haml
@@ -1,3 +1,6 @@
+- content_for(:header_meta) do
+  %meta{ "http-equiv": "refresh", content: "300" }
+
 .header
   %h2 Checks
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,6 +5,7 @@
     = csrf_meta_tags
     = csp_meta_tag
     %meta{ name: "viewport", content: "width=device-width, initial-scale=1.0" }/
+    = content_for(:header_meta)
 
     = stylesheet_link_tag("application",
                           media: "all",

--- a/spec/actions/check/run_all_outdated_spec.rb
+++ b/spec/actions/check/run_all_outdated_spec.rb
@@ -3,15 +3,15 @@
 require "rails_helper"
 
 RSpec.describe Check::RunAllOutdated do
-  it "runs checks that have not been updated in an hour" do
-    check = create_check(counts: [{ created_at: 61.minutes.ago }])
+  it "runs checks that have not been updated in the last five minutes" do
+    check = create_check(counts: [{ created_at: 6.minutes.ago }])
 
     expect { described_class.call }
       .to change(check.counts, :count).by(1)
   end
 
-  it "does not run checks that have been updated in the last hour" do
-    check = create_check(counts: [{ created_at: 59.minutes.ago }])
+  it "does not run checks that have been updated in the last five minutes" do
+    check = create_check(counts: [{ created_at: 4.minutes.ago }])
 
     expect { described_class.call }
       .not_to change(check.counts, :count)


### PR DESCRIPTION
This adds a `meta` tag to automatically refresh the page every 5
minutes, as well as reducing the refresh window for checks from 1 hour
to 5 minutes. The `meta` tag is maybe a tad hacky, but it's a good quick
alternative before we get more ajaxy stuff in place.
