### PR TITLE
Feature: allow editing target value

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -7,11 +7,35 @@ class ChecksController < ApplicationController
 
   def new; end
 
+  def edit
+    render(locals: { check: find_check(params[:id]) })
+  end
+
+  def update
+    check = find_check(params[:id])
+    if check.update(check_params)
+      flash[:success] = "Check updated"
+      redirect_to(checks_path)
+    else
+      flash.now[:error] = "Unable to update check"
+      render(:edit, locals: { check: check })
+    end
+  end
+
   def destroy
-    check = current_user.checks.find(params[:id])
-    check.destroy!
+    find_check(params[:id]).destroy!
 
     flash[:success] = "Check deleted"
     redirect_to(checks_path)
+  end
+
+  private
+
+  def check_params
+    params.require(:check).permit(:name, :target)
+  end
+
+  def find_check(id)
+    current_user.checks.find(id)
   end
 end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -5,7 +5,7 @@ class Check < ApplicationRecord
   belongs_to :integration
   has_many :counts, class_name: "CheckCount", dependent: :delete_all
   validates :name, presence: true, uniqueness: { scope: :user_id }
-  validates :integration_id, :user_id, presence: true
+  validates :integration_id, :user_id, :target, presence: true
   scope(
     :last_counted_before,
     lambda { |timestamp|
@@ -25,7 +25,7 @@ class Check < ApplicationRecord
   end # class << self
 
   def active?
-    last_value.present? && last_value.positive?
+    last_value.present? && last_value > target
   end
 
   def refresh

--- a/app/views/checks/_list.html.haml
+++ b/app/views/checks/_list.html.haml
@@ -7,6 +7,8 @@
         - data = { confirm: "delete check? #{check.name}" }
         = link_to(check_path(check), method: :delete, data: data) do
           = icon("far", "trash-alt")
+        = link_to(edit_check_path(check)) do
+          = icon("fas", "pen")
       %p
         %span.check_value= check.last_value
         = link_to(check.url, target: :_blank, rel: :noreferrer) do

--- a/app/views/checks/edit.html.haml
+++ b/app/views/checks/edit.html.haml
@@ -1,0 +1,22 @@
+%h1
+  Editing Check:
+  %em= check.name
+
+= form_with(model: check) do |form|
+  - if check.errors.any?
+    .error_explanation
+      %h2 #{pluralize(check.errors.count, "error")} problems with your signup:
+      %ul
+        - check.errors.full_messages.each do |message|
+          %li= message
+
+  .field
+    = form.label(:name)
+    = form.text_field(:name, required: true)
+
+  .field
+    = form.label(:target)
+    = form.number_field(:target, required: true)
+
+  .actions
+    = form.submit("Update Check")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
 
   resource :account, only: [:new, :create, :show, :update, :destroy]
   resource :session, only: [:new, :create, :destroy]
-  resources :checks, only: [:index, :new, :destroy]
+  resources :checks, only: [:index, :new, :edit, :update, :destroy]
   resources :trello_integrations, only: [:new] do
     resources :checks, only: [:new, :create], controller: "trello_checks"
   end

--- a/db/migrate/20210206031210_add_target_to_checks.rb
+++ b/db/migrate/20210206031210_add_target_to_checks.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddTargetToChecks < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_column :checks, :target, :integer, null: false, default: 0
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_12_213655) do
+ActiveRecord::Schema.define(version: 2021_02_06_031210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2020_04_12_213655) do
     t.string "type", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "target", default: 0, null: false
     t.index ["integration_id"], name: "index_checks_on_integration_id"
     t.index ["user_id", "name"], name: "index_checks_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_checks_on_user_id"

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -13,6 +13,68 @@ RSpec.describe ChecksController, type: :controller do
     end
   end
 
+  describe "#edit" do
+    it "renders the edit page for a check" do
+      check = create_check
+      login_as(check.user)
+
+      get(:edit, params: { id: check.id })
+
+      expect(rendered).to have_content("Editing Check: #{check.name}")
+    end
+  end
+
+  describe "#update" do
+    context "when params are valid" do
+      it "updates the check" do
+        check = create_check
+        login_as(check.user)
+
+        put(:update, params: { id: check.id, check: { target: 5 } })
+
+        expect(check.reload.target).to eq(5)
+      end
+
+      it "redirects to checks/index" do
+        check = create_check
+        login_as(check.user)
+
+        put(:update, params: { id: check.id, check: { target: 5 } })
+
+        expect(response).to redirect_to(checks_path)
+      end
+
+      it "flashes a success message" do
+        check = create_check
+        login_as(check.user)
+
+        put(:update, params: { id: check.id, check: { target: 5 } })
+
+        expect(flash[:success]).to eq("Check updated")
+      end
+    end
+
+    context "when params are invalid" do
+      it "flashes an error message" do
+        check = create_check
+        login_as(check.user)
+
+        put(:update, params: { id: check.id, check: { target: "" } })
+
+        expect(response.body).to include("Unable to update check")
+      end
+
+      it "renders the edit view" do
+        check = create_check
+        login_as(check.user)
+
+        put(:update, params: { id: check.id, check: { target: "" } })
+
+        expect(rendered).to have_content("Editing Check: #{check.name}")
+      end
+    end
+  end
+
   describe "#destroy" do
     it "deletes the check" do
       check = create_check

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe Check, type: :model do
   it { is_expected.to belong_to(:integration) }
   it { is_expected.to belong_to(:user) }
   it { is_expected.to have_many(:counts).class_name("CheckCount").dependent(:delete_all) }
+  it { is_expected.to validate_presence_of(:integration_id) }
   it { is_expected.to validate_presence_of(:user_id) }
+  it { is_expected.to validate_presence_of(:target) }
 
   describe ".last_counted_before" do
     it "returns checks with counts prior to timestamp" do
@@ -47,6 +49,24 @@ RSpec.describe Check, type: :model do
       check = create_check
 
       expect(check.active?).to be(false)
+    end
+
+    it "returns false when most recent count < target value" do
+      check = create_check(counts: [{ value: 1 }], target: 2)
+
+      expect(check.active?).to be(false)
+    end
+
+    it "returns false when most recent count == target value" do
+      check = create_check(counts: [{ value: 1 }], target: 1)
+
+      expect(check.active?).to be(false)
+    end
+
+    it "returns true when most recent count > target value" do
+      check = create_check(counts: [{ value: 2 }], target: 1)
+
+      expect(check.active?).to be(true)
     end
   end
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -20,4 +20,12 @@ RSpec.configure do |config|
   config.before(:each, type: :system, js: true) do
     driven_by(driver || :selenium_headless)
   end
+
+  config.before(:each, type: :controller) do
+    Capybara.default_normalize_ws = true
+  end
+
+  config.after(:each, type: :controller) do
+    Capybara.default_normalize_ws = false
+  end
 end

--- a/spec/support/capybara/page/check.rb
+++ b/spec/support/capybara/page/check.rb
@@ -11,5 +11,9 @@ module Page
     def delete_icon
       element.find(".fa-trash-alt")
     end
+
+    def edit_icon
+      element.find(".fa-pen")
+    end
   end
 end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
 module Factories
-  def create_check(counts: [])
+  def create_check(counts: [], target: 0)
     integration = create_integration
     check = Test::Check.create!(
       name: "some check",
       integration: integration,
       user: integration.user,
+      target: target,
     )
+    create_counts(check, counts)
+    check
+  end
+
+  def create_counts(check, counts)
     counts.each do |count_params|
       create_count(count_params.merge(check: check))
     end
-    check
   end
 
   def create_count(params)

--- a/spec/system/checks/edit_spec.rb
+++ b/spec/system/checks/edit_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "checks/edit", type: :system, js: true do
+  def update_check(check, **params)
+    visit(edit_check_path(check))
+
+    params.each do |field, value|
+      fill_in(field, with: value)
+    end
+
+    click_button("Update Check")
+  end
+
+  it "allows editing a check" do
+    check = create_check(counts: [{ value: 5 }])
+    sign_in(check.user)
+    expect(page).to have_active_check(check.name, text: check.message)
+
+    update_check(check, Target: 5)
+
+    expect(page).to have_inactive_check(check.name, text: check.message)
+  end
+end

--- a/spec/system/checks/index_spec.rb
+++ b/spec/system/checks/index_spec.rb
@@ -32,4 +32,21 @@ RSpec.describe "checks/index", type: :system, js: true do
     expect(page).to have_inactive_check(check.name, text: check.message)
     expect(page).to have_no_active_checks
   end
+
+  it "displays checks that are below target in inactive section" do
+    check = create_check(counts: [{ value: 5 }], target: 6)
+    sign_in(check.user)
+
+    expect(page).to have_inactive_check(check.name, text: check.message)
+    expect(page).to have_no_active_checks
+  end
+
+  it "links to the edit checks page" do
+    check = create_check
+    sign_in(check.user)
+
+    find_check(check.name).edit_icon.click
+
+    expect(page).to have_content("Editing Check: #{check.name}")
+  end
 end


### PR DESCRIPTION
**What**

This introduces a new `target` field to checks so that a custom value
can be specified for when a check is active.

**Notes**

The layout on the `checks/index` page is getting pretty messy. I need to
follow up with some cleanups.
