### PR TITLE
Layout: adjust card actions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -179,6 +179,9 @@ hr {
 }
 
 .card {
+  display: grid;
+  grid-template-columns: auto 10px;
+
   h3 {
     font-size: 1.5em;
     margin-bottom: 25px;
@@ -206,6 +209,13 @@ hr {
   border-radius: 15px;
 }
 
+.card-actions {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  font-size: 1.25em;
+}
+
 .check_value {
   font-weight: bold;
   border-radius: 50%;
@@ -216,10 +226,4 @@ hr {
   color: #555;
   font-size: 20px;
   line-height: 30px;
-}
-
-.fa-trash-alt {
-  float: right;
-  margin-top: -10px;
-  margin-right: -10px;
 }

--- a/app/views/checks/_list.html.haml
+++ b/app/views/checks/_list.html.haml
@@ -1,16 +1,18 @@
 .card-list
   - checks.each do |check|
     .card
-      %h3
-        = icon("fab", check.service, class: "fa-lg")
-        = check.name
-        - data = { confirm: "delete check? #{check.name}" }
-        = link_to(check_path(check), method: :delete, data: data) do
-          = icon("far", "trash-alt")
+      .card-main
+        %h3
+          = icon("fab", check.service, class: "fa-lg")
+          = check.name
+          - data = { confirm: "delete check? #{check.name}" }
+        %p
+          %span.check_value= check.last_value
+          = link_to(check.url, target: :_blank, rel: :noreferrer) do
+            = check.message
+            %span.fas.fa-external-link-alt
+      .card-actions
         = link_to(edit_check_path(check)) do
           = icon("fas", "pen")
-      %p
-        %span.check_value= check.last_value
-        = link_to(check.url, target: :_blank, rel: :noreferrer) do
-          = check.message
-          %span.fas.fa-external-link-alt
+        = link_to(check_path(check), method: :delete, data: data) do
+          = icon("far", "trash-alt")

--- a/spec/support/capybara/page/check.rb
+++ b/spec/support/capybara/page/check.rb
@@ -4,6 +4,10 @@ module Page
   class Check
     attr_accessor :element
 
+    def self.find(page, check)
+      new(page.find(".card", text: check.name))
+    end
+
     def initialize(element)
       self.element = element
     end

--- a/spec/support/matchers/have_check.rb
+++ b/spec/support/matchers/have_check.rb
@@ -42,6 +42,8 @@ module Matchers
 
     attr_accessor :element, :expected_name, :expected_text
 
+    NAME_SELECTOR = ".card h3"
+
     def initialize(expected_name, text:)
       self.expected_name = expected_name
       self.expected_text = text
@@ -65,7 +67,7 @@ module Matchers
     def no_check_with_name_message
       <<~MESSAGE.squish
         expected to find check with name "#{expected_name}" but found checks
-        with names: #{element.all("h3").map(&:text)}
+        with names: #{element.all(NAME_SELECTOR).map(&:text)}
       MESSAGE
     end
 
@@ -77,7 +79,7 @@ module Matchers
     end
 
     def has_name?
-      element.has_selector?(".card > h3", text: expected_name)
+      element.has_selector?(NAME_SELECTOR, text: expected_name)
     end
 
     def has_text?
@@ -85,7 +87,7 @@ module Matchers
     end
 
     def check
-      element.find(".card > h3", text: expected_name).find(:xpath, "..")
+      element.find(NAME_SELECTOR, text: expected_name).find(:xpath, "..")
     end
   end
 end

--- a/spec/system/checks/index_spec.rb
+++ b/spec/system/checks/index_spec.rb
@@ -3,15 +3,15 @@
 require "rails_helper"
 
 RSpec.describe "checks/index", type: :system, js: true do
-  def find_check(name)
-    Page::Check.new(find(".card > h3", text: name))
+  def find_check(check)
+    Page::Check.find(page, check)
   end
 
   it "allows deleting checks" do
     check = create_check
     sign_in(check.user)
 
-    accept_confirm { find_check(check.name).delete_icon.click }
+    accept_confirm { find_check(check).delete_icon.click }
 
     expect(page).to have_flash(:success, "Check deleted")
     expect(page).to have_no_checks
@@ -45,7 +45,7 @@ RSpec.describe "checks/index", type: :system, js: true do
     check = create_check
     sign_in(check.user)
 
-    find_check(check.name).edit_icon.click
+    find_check(check).edit_icon.click
 
     expect(page).to have_content("Editing Check: #{check.name}")
   end


### PR DESCRIPTION
Moves edit and delete icons to the right side of the card. This will
also accommodate additional actions as they're added. Refresh in
particular.
