### PR TITLE
CodeQuality: move data line down

### DIFF
--- a/app/views/checks/_list.html.haml
+++ b/app/views/checks/_list.html.haml
@@ -5,7 +5,6 @@
         %h3
           = icon("fab", check.service, class: "fa-lg")
           = check.name
-          - data = { confirm: "delete check? #{check.name}" }
         %p
           %span.check_value= check.last_value
           = link_to(check.url, target: :_blank, rel: :noreferrer) do
@@ -14,5 +13,6 @@
       .card-actions
         = link_to(edit_check_path(check)) do
           = icon("fas", "pen")
+        - data = { confirm: "delete check? #{check.name}" }
         = link_to(check_path(check), method: :delete, data: data) do
           = icon("far", "trash-alt")


### PR DESCRIPTION
It seems to still work where it is, but moving it down to where it is
used.
