### PR TITLE
Rubocop: set LineLength to 80 characters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,7 @@ AllCops:
 # https://github.com/rubocop-hq/rubocop/issues/7841
 Style/TrailingCommaInBlockArgs: { Enabled: false }
 Layout/LineLength:
+  Max: 80
   Exclude:
     - 'config/**/*'
   AutoCorrect: true
@@ -30,6 +31,7 @@ Metrics/BlockLength:
     - Guardfile
 Rails/Delegate: { Exclude: [spec/support/matchers/**/*.rb] }
 Rails/FilePath: { EnforcedStyle: slashes }
+RSpec/ImplicitSubject: { EnforcedStyle: single_statement_only }
 RSpec/MultipleExpectations:
   Exclude:
     - spec/system/**/*.rb

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -5,7 +5,12 @@ require "rails_helper"
 RSpec.describe Check, type: :model do
   it { is_expected.to belong_to(:integration) }
   it { is_expected.to belong_to(:user) }
-  it { is_expected.to have_many(:counts).class_name("CheckCount").dependent(:delete_all) }
+
+  it {
+    is_expected
+      .to have_many(:counts).class_name("CheckCount").dependent(:delete_all)
+  }
+
   it { is_expected.to validate_presence_of(:integration_id) }
   it { is_expected.to validate_presence_of(:user_id) }
   it { is_expected.to validate_presence_of(:target) }

--- a/spec/support/matchers/invoke_matcher.rb
+++ b/spec/support/matchers/invoke_matcher.rb
@@ -65,9 +65,13 @@ module Matchers
     def receive_expected
       receive_expected = receive(@expected_method)
 
-      receive_expected = receive_expected.and_return(*@return_arguments) if defined?(@return_arguments)
+      if defined?(@return_arguments)
+        receive_expected = receive_expected.and_return(*@return_arguments)
+      end
 
-      receive_expected = receive_expected.and_call_original if defined?(@and_call_original)
+      if defined?(@and_call_original)
+        receive_expected = receive_expected.and_call_original
+      end
 
       receive_expected
     end
@@ -85,7 +89,9 @@ module Matchers
         begin
           matcher = RSpec::Mocks::Matchers::HaveReceived.new(@expected_method)
 
-          matcher = matcher.with(*@expected_arguments) if defined?(@expected_arguments)
+          if defined?(@expected_arguments)
+            matcher = matcher.with(*@expected_arguments)
+          end
 
           matcher = matcher.exactly(@times).times if defined?(@times)
 


### PR DESCRIPTION
Looks like the default has been moved up to 120. A bit much for my
taste.
