### PR TITLE
Remove `message` method from checks

### DIFF
--- a/app/models/check/github/user_has_assigned_pull_requests.rb
+++ b/app/models/check/github/user_has_assigned_pull_requests.rb
@@ -8,7 +8,7 @@ class Check < ApplicationRecord
       STEPS = ["name"].freeze
 
       def service
-        "github"
+        "GitHub"
       end
 
       def next_count
@@ -17,10 +17,6 @@ class Check < ApplicationRecord
 
       def next_step
         STEPS.find { |step| public_send(step).nil? }
-      end
-
-      def message
-        "assigned pull requests"
       end
 
       def url

--- a/app/models/check/trello/list_has_cards.rb
+++ b/app/models/check/trello/list_has_cards.rb
@@ -12,7 +12,7 @@ class Check < ApplicationRecord
       STEPS = ["board_id", "list_id", "name"].freeze
 
       def service
-        "trello"
+        "Trello"
       end
 
       def next_count
@@ -21,10 +21,6 @@ class Check < ApplicationRecord
 
       def next_step
         STEPS.find { |step| public_send(step).nil? }
-      end
-
-      def message
-        "cards in #{list.name}"
       end
 
       def board

--- a/app/views/checks/_list.html.haml
+++ b/app/views/checks/_list.html.haml
@@ -3,12 +3,12 @@
     .card
       .card-main
         %h3
-          = icon("fab", check.service, class: "fa-lg")
+          = icon("fab", check.service.downcase, class: "fa-lg")
           = check.name
         %p
           %span.check_value= check.last_value
           = link_to(check.url, target: :_blank, rel: :noreferrer) do
-            = check.message
+            visit #{check.service}
             %span.fas.fa-external-link-alt
       .card-actions
         - params = { check: { refresh: true } }

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -2,16 +2,16 @@
 
 Dir[File.join(__dir__, "./matchers/*.rb")].sort.each { |path| require path }
 
-def have_check(expected_name, text:)
-  Matchers::HaveCheck.new(expected_name, text: text)
+def have_check(expected_name)
+  Matchers::HaveCheck.new(expected_name)
 end
 
-def have_active_check(expected_name, text:)
-  Matchers::HaveActiveCheck.new(expected_name, text: text)
+def have_active_check(expected_name)
+  Matchers::HaveActiveCheck.new(expected_name)
 end
 
-def have_inactive_check(expected_name, text:)
-  Matchers::HaveInactiveCheck.new(expected_name, text: text)
+def have_inactive_check(expected_name)
+  Matchers::HaveInactiveCheck.new(expected_name)
 end
 
 def have_no_checks

--- a/spec/support/matchers/have_check.rb
+++ b/spec/support/matchers/have_check.rb
@@ -40,26 +40,21 @@ module Matchers
       end
     end
 
-    attr_accessor :element, :expected_name, :expected_text
+    attr_accessor :element, :expected_name
 
     NAME_SELECTOR = ".card h3"
 
-    def initialize(expected_name, text:)
+    def initialize(expected_name)
       self.expected_name = expected_name
-      self.expected_text = text
     end
 
     def matches?(page)
       self.element = MemoizedElement.new(page)
-      has_name? && has_text?
+      has_name?
     end
 
     def failure_message
-      if !has_name?
-        no_check_with_name_message
-      elsif !has_text?
-        check_has_wrong_text_message
-      end
+      no_check_with_name_message
     end
 
     private
@@ -71,23 +66,8 @@ module Matchers
       MESSAGE
     end
 
-    def check_has_wrong_text_message
-      <<~MESSAGE.squish
-        expected check with name "#{expected_name}" to have text
-        "#{expected_text}" but had "#{check.find("p").text}"
-      MESSAGE
-    end
-
     def has_name?
       element.has_selector?(NAME_SELECTOR, text: expected_name)
-    end
-
-    def has_text?
-      check.has_selector?("p", text: expected_text)
-    end
-
-    def check
-      element.find(NAME_SELECTOR, text: expected_name).find(:xpath, "..")
     end
   end
 end

--- a/spec/system/checks/edit_spec.rb
+++ b/spec/system/checks/edit_spec.rb
@@ -16,23 +16,23 @@ RSpec.describe "checks/edit", type: :system, js: true do
   end
 
   def expect_check_to_activate(check)
-    expect(page).to have_inactive_check(check.name, text: check.message)
+    expect(page).to have_inactive_check(check.name)
 
     yield
 
     find_check(check).refresh_icon.click
 
-    expect(page).to have_active_check(check.name, text: check.message)
+    expect(page).to have_active_check(check.name)
   end
 
   it "allows editing a check" do
     check = create_check(counts: [{ value: 5 }])
     sign_in(check.user)
-    expect(page).to have_active_check(check.name, text: check.message)
+    expect(page).to have_active_check(check.name)
 
     update_check(check, Target: 5)
 
-    expect(page).to have_inactive_check(check.name, text: check.message)
+    expect(page).to have_inactive_check(check.name)
   end
 
   it "allows setting a moving target on a check" do

--- a/spec/system/checks/index_spec.rb
+++ b/spec/system/checks/index_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "checks/index", type: :system, js: true do
     check = create_check(counts: [{ value: 5 }])
     sign_in(check.user)
 
-    expect(page).to have_active_check(check.name, text: check.message)
+    expect(page).to have_active_check(check.name)
     expect(page).to have_no_inactive_checks
   end
 
@@ -29,7 +29,7 @@ RSpec.describe "checks/index", type: :system, js: true do
     check = create_check
     sign_in(check.user)
 
-    expect(page).to have_inactive_check(check.name, text: check.message)
+    expect(page).to have_inactive_check(check.name)
     expect(page).to have_no_active_checks
   end
 
@@ -37,7 +37,7 @@ RSpec.describe "checks/index", type: :system, js: true do
     check = create_check(counts: [{ value: 5 }], target: { value: 6 })
     sign_in(check.user)
 
-    expect(page).to have_inactive_check(check.name, text: check.message)
+    expect(page).to have_inactive_check(check.name)
     expect(page).to have_no_active_checks
   end
 
@@ -57,6 +57,6 @@ RSpec.describe "checks/index", type: :system, js: true do
 
     find_check(check).refresh_icon.click
 
-    expect(page).to have_active_check(check.name, text: check.message)
+    expect(page).to have_active_check(check.name)
   end
 end

--- a/spec/system/github_integration_spec.rb
+++ b/spec/system/github_integration_spec.rb
@@ -47,6 +47,6 @@ RSpec.describe "GitHub integration", type: :system, js: true do
     authenticate_with_github
     create_github_check(name: "Pulls for Me")
 
-    expect(page).to have_check("Pulls for Me", text: "2 assigned pull requests")
+    expect(page).to have_check("Pulls for Me")
   end
 end

--- a/spec/system/trello_integration_spec.rb
+++ b/spec/system/trello_integration_spec.rb
@@ -65,6 +65,6 @@ RSpec.describe "Trello integration", type: :system, js: true do
     authenticate_with_trello
     create_trello_check(board: "Dev Board", list: "Inbox", name: "Inbox cards")
 
-    expect(page).to have_check("Inbox cards", text: "3 cards in Inbox")
+    expect(page).to have_check("Inbox cards")
   end
 end


### PR DESCRIPTION
The message was redundant with the name, so we can make it a little more
generic.
