### PR TITLE
Allow refreshing targets when no checks are active

### DIFF
--- a/app/actions/check/target/refresh.rb
+++ b/app/actions/check/target/refresh.rb
@@ -5,8 +5,8 @@ class Check < ApplicationRecord
     class Refresh
       include JunkDrawer::Callable
 
-      def call(target)
-        return if target.next_refresh_at > Time.zone.now
+      def call(target, force: false)
+        return if target.next_refresh_at > Time.zone.now && !force
 
         next_value = [target.goal_value, target.value - target.delta].max
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -135,14 +135,24 @@ hr {
 
 .new-check-btn {
   float: right;
+}
+
+.btn-primary {
   padding: 9px 12px;
   font-size: 18px;
+  border: none;
   border-radius: 4px;
   text-align: center;
   color: #fff;
+  cursor: pointer;
   background-color: rgba(71, 120, 186, 1);
   text-decoration: none;
   font-weight: bold;
+  transition: background-color 0.2s linear;
+
+  &:hover {
+    background-color: rgba(71, 120, 186, 0.8);
+  }
 }
 
 @media (max-width: 400px) {

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -2,7 +2,12 @@
 
 class ChecksController < ApplicationController
   def index
-    render(locals: { checks: current_user.checks })
+    render(
+      locals: {
+        checks: current_user.checks,
+        unreached_goal_targets: current_user.targets.unreached_goal,
+      },
+    )
   end
 
   def new; end

--- a/app/controllers/targets_controller.rb
+++ b/app/controllers/targets_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class TargetsController < ApplicationController
+  def update
+    current_user.targets.unreached_goal.each do |target|
+      Check::Target::Refresh.call(target, force: true)
+    end
+
+    redirect_to(checks_path)
+  end
+end

--- a/app/models/check/target.rb
+++ b/app/models/check/target.rb
@@ -6,7 +6,12 @@ class Check < ApplicationRecord
     attribute :goal_value, :integer, default: 0
     attribute :next_refresh_at, :datetime, default: -> { Time.zone.tomorrow }
     attribute :value, :integer, default: 0
+
     belongs_to :check
+
+    delegate :user, to: :check
+    delegate :name, to: :check, prefix: true
+
     validates :check_id, uniqueness: true
     validates :value,
               :check,
@@ -14,5 +19,7 @@ class Check < ApplicationRecord
               :goal_value,
               :next_refresh_at,
               presence: true
+
+    scope :unreached_goal, -> { where("goal_value != value") }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
 
   has_many :integrations, dependent: :restrict_with_exception
   has_many :checks, dependent: :restrict_with_exception
+  has_many :targets, through: :checks
 
   validates :email, presence: true, format: URI::MailTo::EMAIL_REGEXP
 

--- a/app/views/checks/index.html.haml
+++ b/app/views/checks/index.html.haml
@@ -2,14 +2,24 @@
   %meta{ "http-equiv": "refresh", content: "300" }
 
 .header
-  = link_to("+ New Check", new_check_path, class: "new-check-btn")
+  = link_to("+ New Check", new_check_path, class: "btn-primary new-check-btn")
 
 - active_checks, inactive_checks = checks.partition(&:active?)
 
 .active
   %h2 Active Checks
 
-  = render("list", checks: active_checks)
+  - if active_checks.any?
+    = render("list", checks: active_checks)
+  - else
+    %h3 Congrats you have no active checks!
+
+    - if unreached_goal_targets.any?
+      = button_to("Refresh All Targets",
+        targets_path,
+        remote: false,
+        method: :patch,
+        class: "btn-primary")
 
 .inactive
   %hr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
 
   resource :account, only: [:new, :create, :show, :update, :destroy]
   resource :session, only: [:new, :create, :destroy]
+  resource :targets, only: [:update]
 
   resources :checks, only: [:index, :new, :edit, :update, :destroy] do
     resources :counts, only: [:new, :create], controller: "check_counts"

--- a/spec/actions/check/target/refresh_spec.rb
+++ b/spec/actions/check/target/refresh_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe Check::Target::Refresh do
   it "does nothing when next_refresh_at is in future" do
-    target = create_target(next_refresh_at: 2.days.from_now.beginning_of_day)
+    target = create_target(value: 2, delta: 1)
 
     expect { described_class.call(target) }
       .to not_change_record(target, :next_refresh_at)
@@ -25,7 +25,7 @@ RSpec.describe Check::Target::Refresh do
   end
 
   it "subtracts the delta from the value" do
-    target = create_target(next_refresh_at: 1.day.ago, value: 50, delta: 6)
+    target = create_target(:refreshable, value: 50, delta: 6)
 
     expect { described_class.call(target) }
       .to change_record(target, :value).to(44)
@@ -36,5 +36,12 @@ RSpec.describe Check::Target::Refresh do
 
     expect { described_class.call(target) }
       .to change_record(target, :value).to(48)
+  end
+
+  it "updates the value when next_refresh_at is in future and force is true" do
+    target = create_target(value: 2, delta: 1)
+
+    expect { described_class.call(target, force: true) }
+      .to change_record(target, :value).from(2).to(1)
   end
 end

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -5,12 +5,30 @@ require "rails_helper"
 RSpec.describe ChecksController, type: :controller do
   describe "#index" do
     it "renders the checks page" do
-      session[:user_id] = User.create!(user_params).id
+      login_as(create_user)
 
       get(:index)
 
-      expect(response.body).to include("Checks")
+      expect(rendered).to have_content("Checks")
     end
+  end
+
+  it "displays Refresh All Targets when targets have unreached goal" do
+    check = create_check(counts: [{ value: 3 }], target: { value: 5, delta: 5 })
+    login_as(check.user)
+
+    get(:index)
+
+    expect(rendered).to have_button("Refresh All Targets")
+  end
+
+  it "does not display Refresh All Targets when all targets match goal" do
+    check = create_check(counts: [{ value: 0 }])
+    login_as(check.user)
+
+    get(:index)
+
+    expect(rendered).to have_no_button("Refresh All Targets")
   end
 
   describe "#edit" do

--- a/spec/models/check/target_spec.rb
+++ b/spec/models/check/target_spec.rb
@@ -4,15 +4,36 @@ require "rails_helper"
 
 RSpec.describe Check::Target, type: :model do
   it { is_expected.to belong_to(:check) }
+
   it { is_expected.to validate_presence_of(:check) }
   it { is_expected.to validate_presence_of(:value) }
   it { is_expected.to validate_presence_of(:delta) }
   it { is_expected.to validate_presence_of(:goal_value) }
   it { is_expected.to validate_presence_of(:next_refresh_at) }
 
+  it { is_expected.to delegate_method(:user).to(:check) }
+  it { is_expected.to delegate_method(:name).to(:check).with_prefix(true) }
+
   it do
     create_check
 
     expect(described_class.new).to validate_uniqueness_of(:check_id)
+  end
+
+  describe ".unreached_goal" do
+    it "returns targets where goal_value != value" do
+      target1 = create_target(value: 5, goal_value: 0)
+      target2 = create_target(value: 0, goal_value: 5)
+      expected_targets = [target1, target2]
+
+      expect(described_class.unreached_goal).to match_array(expected_targets)
+    end
+
+    it "does not return targets where goal_value == value" do
+      create_target(value: 5, goal_value: 5)
+      create_target(value: 0, goal_value: 0)
+
+      expect(described_class.unreached_goal).to be_empty
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
+  it { is_expected.to have_many(:targets).through(:checks) }
+
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to have_secure_password }
 

--- a/spec/requests/targets_controller_spec.rb
+++ b/spec/requests/targets_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TargetsController do
+  describe "#update" do
+    it "refreshes unreached goal targets" do
+      target = create_target(value: 5, delta: 5)
+      login_as(target.user)
+
+      expect { patch(targets_path) }
+        .to change_record(target, :value).from(5).to(0)
+    end
+
+    it "does not refresh targets that match their goal" do
+      target = create_target(value: 5, goal_value: 5, delta: 5)
+      login_as(target.user)
+
+      expect { patch(targets_path) }
+        .to not_change_record(target, :value).from(5)
+    end
+
+    it "redirects to checks/index" do
+      login_as(create_user)
+
+      patch(targets_path)
+
+      expect(response).to redirect_to(checks_path)
+    end
+  end
+end

--- a/spec/system/checks/index_spec.rb
+++ b/spec/system/checks/index_spec.rb
@@ -59,4 +59,15 @@ RSpec.describe "checks/index", type: :system, js: true do
 
     expect(page).to have_active_check(check.name)
   end
+
+  it "displays a button to refresh targets when no active checks" do
+    check = create_check(counts: [{ value: 3 }], target: { value: 5, delta: 5 })
+    sign_in(check.user)
+
+    expect(page).to have_inactive_check(check.name)
+
+    click_button("Refresh All Targets")
+
+    expect(page).to have_active_check(check.name)
+  end
 end


### PR DESCRIPTION
This adds a button to refresh targets immediately when no checks are
active.
