### PR TITLE
introduce API keys

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,7 @@ Style/MethodCallWithArgsParentheses:
     - gem
     - has_many
     - has_one
+    - has_secure_token
     - helper_method
     - include
     - it

--- a/app/actions/user/api_key_find.rb
+++ b/app/actions/user/api_key_find.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class User < ApplicationRecord
+  class ApiKeyFind
+    include JunkDrawer::Callable
+
+    def call(headers)
+      user = User.find(headers["X-User-ID"])
+
+      validate_api_key(user, headers["X-API-Key"])
+
+      user
+    end
+
+    private
+
+    def validate_api_key(user, api_key_string)
+      return if api_key_matches?(user, api_key_string)
+
+      raise ActiveRecord::RecordNotFound
+    end
+
+    def api_key_matches?(user, api_key_string)
+      user.api_keys.any? { |api_key| api_key == api_key_string }
+    end
+  end
+end

--- a/app/actions/user/request_find.rb
+++ b/app/actions/user/request_find.rb
@@ -7,6 +7,8 @@ class User < ApplicationRecord
     def call(request)
       if request.session.key?(:user_id)
         User::SessionFind.call(request.session)
+      elsif request.headers.key?("X-User-Id")
+        User::ApiKeyFind.call(request.headers)
       else
         NullUser.new
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ require "action_controller"
 
 class ApplicationController < ActionController::Base
   before_action(:authenticate_user)
+  protect_from_forgery(with: :exception, unless: :api_request?)
 
   private
 
@@ -24,5 +25,9 @@ class ApplicationController < ActionController::Base
 
   def authenticate_user
     redirect_to(new_session_path) unless current_user.logged_in?
+  end
+
+  def api_request?
+    request.headers.key?("X-User-ID")
   end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class ApiKey < ApplicationRecord
+  has_secure_token :value
+
+  belongs_to :user
+
+  validates :name, :user_id, presence: true
+
+  def ==(other)
+    if other.is_a?(String)
+      ActiveSupport::SecurityUtils.secure_compare(other, value)
+    else
+      super
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,9 +3,10 @@
 class User < ApplicationRecord
   has_secure_password
 
-  has_many :integrations, dependent: :restrict_with_exception
-  has_many :checks, dependent: :restrict_with_exception
+  has_many :integrations, dependent: :delete_all
+  has_many :checks, dependent: :delete_all
   has_many :targets, through: :checks
+  has_many :api_keys, dependent: :delete_all
 
   validates :email, presence: true, format: URI::MailTo::EMAIL_REGEXP
 

--- a/db/migrate/20210219183719_create_api_keys.rb
+++ b/db/migrate/20210219183719_create_api_keys.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateApiKeys < ActiveRecord::Migration[6.1]
+  def change
+    create_table :api_keys do |t|
+      t.references(:user, foreign_key: true, null: false)
+      t.string(:name, null: false)
+      t.string(:value, null: false, index: { unique: true })
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,16 @@ ActiveRecord::Schema.define(version: 2021_02_25_214921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "api_keys", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name", null: false
+    t.string "value", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_api_keys_on_user_id"
+    t.index ["value"], name: "index_api_keys_on_value", unique: true
+  end
+
   create_table "check_counts", force: :cascade do |t|
     t.bigint "check_id", null: false
     t.bigint "value", null: false
@@ -67,6 +77,7 @@ ActiveRecord::Schema.define(version: 2021_02_25_214921) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "api_keys", "users"
   add_foreign_key "check_counts", "checks"
   add_foreign_key "check_targets", "checks"
   add_foreign_key "checks", "integrations"

--- a/spec/actions/user/api_key_find_spec.rb
+++ b/spec/actions/user/api_key_find_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe User::ApiKeyFind do
+  it "returns a user when one of their API keys match" do
+    api_key = create_api_key
+    headers = api_key_headers(api_key)
+
+    expect(described_class.call(headers)).to eq(api_key.user)
+  end
+
+  it "raises an error when no user API keys match" do
+    api_key = create_api_key
+    headers = api_key_headers(api_key, value: "foo")
+
+    expect { described_class.call(headers) }
+      .to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  it "raises an error when given a different user" do
+    api_key = create_api_key
+    headers = api_key_headers(api_key, user_id: create_user.id)
+
+    expect { described_class.call(headers) }
+      .to raise_error(ActiveRecord::RecordNotFound)
+  end
+end

--- a/spec/actions/user/request_find_spec.rb
+++ b/spec/actions/user/request_find_spec.rb
@@ -3,10 +3,6 @@
 require "rails_helper"
 
 RSpec.describe User::RequestFind do
-  def make_request(session:)
-    instance_double(ActionDispatch::Request, session: session)
-  end
-
   it "finds the user by session when user_id is present" do
     user = create_user
     request = make_request(session: { user_id: user.id })
@@ -14,8 +10,16 @@ RSpec.describe User::RequestFind do
     expect(described_class.call(request)).to eq(user)
   end
 
+  it "finds the user by api key when present" do
+    api_key = create_api_key
+    headers = api_key_headers(api_key)
+    request = make_request(headers: headers)
+
+    expect(described_class.call(request)).to eq(api_key.user)
+  end
+
   it "returns a NullUser when no session[:user_id]" do
-    request = make_request(session: {})
+    request = make_request
 
     expect(described_class.call(request)).to be_kind_of(NullUser)
   end

--- a/spec/lib/route_constraints/admin_constraint_spec.rb
+++ b/spec/lib/route_constraints/admin_constraint_spec.rb
@@ -4,10 +4,6 @@ require "rails_helper"
 
 RSpec.describe AdminConstraint do
   describe "#matches?" do
-    def make_request(session:)
-      instance_double(ActionDispatch::Request, session: session)
-    end
-
     it "returns true when user is admin" do
       user = create_user(admin: true)
       request = make_request(session: { user_id: user.id })

--- a/spec/models/api_key_spec.rb
+++ b/spec/models/api_key_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApiKey, type: :model do
+  it { is_expected.to have_secure_token(:value) }
+  it { is_expected.to belong_to(:user) }
+  it { is_expected.to validate_presence_of(:name) }
+  it { is_expected.to validate_presence_of(:user_id) }
+
+  describe "#==" do
+    context "when other is a string" do
+      it "returns true when value matches string" do
+        api_key = described_class.new(value: "foo")
+
+        expect(api_key == "foo").to be(true)
+      end
+
+      it "returns false when value does not match string" do
+        api_key = described_class.new(value: "foo")
+
+        expect(api_key == "bar").to be(false)
+      end
+    end
+
+    context "when other is not a string" do
+      it "returns true when given the same record" do
+        api_key = create_api_key
+
+        expect(api_key == described_class.find(api_key.id)).to be(true)
+      end
+
+      it "returns false when given another record" do
+        api_key1 = create_api_key
+        api_key2 = create_api_key
+
+        expect(api_key1 == api_key2).to be(false)
+      end
+
+      it "returns false when given another type of object" do
+        api_key = create_api_key
+
+        expect(api_key == api_key.user).to be(false)
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,10 @@
 require "rails_helper"
 
 RSpec.describe User, type: :model do
+  it { is_expected.to have_many(:integrations).dependent(:delete_all) }
+  it { is_expected.to have_many(:checks).dependent(:delete_all) }
   it { is_expected.to have_many(:targets).through(:checks) }
+  it { is_expected.to have_many(:api_keys).dependent(:delete_all) }
 
   it { is_expected.to validate_presence_of(:email) }
   it { is_expected.to have_secure_password }

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ApplicationController, type: :request do
+  describe "#authenticate_user" do
+    it "finds the user by session" do
+      check = create_check
+      login_as(check.user)
+
+      params = { check_count: { value: 5 } }
+
+      expect { post(check_counts_path(check), params: params) }
+        .to change(check, :last_value).from(nil).to(5)
+    end
+
+    it "finds the user by API key" do
+      check = create_check
+      headers = api_key_headers(create_api_key(user: check.user))
+      post_options = { params: { check_count: { value: 5 } }, headers: headers }
+
+      expect { post(check_counts_path(check), **post_options) }
+        .to change(check, :last_value).from(nil).to(5)
+    end
+
+    context "when user is not found" do
+      it "does not reach the controller action" do
+        check = create_check
+        params = { check_count: { value: 5 } }
+
+        expect { post(check_counts_path(check), params: params) }
+          .not_to change(check, :last_value).from(nil)
+      end
+
+      it "redirects to new_session_path" do
+        check = create_check
+        params = { check_count: { value: 5 } }
+
+        post(check_counts_path(check), params: params)
+
+        expect(response).to redirect_to(new_session_path)
+      end
+    end
+  end
+end

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative "factories/api_keys"
+require_relative "factories/requests"
+
 module Factories
   def create_check(counts: [], target: {})
     integration = create_integration

--- a/spec/support/factories/api_keys.rb
+++ b/spec/support/factories/api_keys.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Factories
+  def create_api_key(**params)
+    build_api_key(**params).tap(&:save!)
+  end
+
+  def build_api_key(user: create_user, name: "Test App", **params)
+    ApiKey.create!(user: user, name: name, **params)
+  end
+
+  def api_key_headers(api_key, user_id: api_key.user_id, value: api_key.value)
+    hash = { "HTTP_X_USER_ID" => user_id, "HTTP_X_API_KEY" => value }
+    ActionDispatch::Http::Headers.from_hash(hash)
+  end
+end

--- a/spec/support/factories/requests.rb
+++ b/spec/support/factories/requests.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Factories
+  def make_request(session: {}, headers: {})
+    request = ActionDispatch::Request.new(headers)
+    request.session = session
+    request
+  end
+end


### PR DESCRIPTION
This introduces the backend for API keys, which will allow users to
write their own services to ping manual checks. It's enough for my
purposes, but it lacks a frontend for creating keys, and friendly
responses when a user pings the API with json format.
