### PR TITLE
fix for missing preload in RunAllOutdated

### DIFF
--- a/app/actions/check/run_all_outdated.rb
+++ b/app/actions/check/run_all_outdated.rb
@@ -11,7 +11,7 @@ class Check < ApplicationRecord
     private
 
     def stale_checks
-      Check.last_counted_before(5.minutes.ago).preload(:target)
+      Check.last_counted_before(5.minutes.ago).preload(:integration, :target)
     end
   end
 end


### PR DESCRIPTION
This threw an error in production.
