### PR TITLE
fix another strict_loading error

### DIFF
--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -47,6 +47,6 @@ class ChecksController < ApplicationController
   end
 
   def find_check(id)
-    current_user.checks.preload(:target).find(id)
+    current_user.checks.preload(:integration, :target).find(id)
   end
 end


### PR DESCRIPTION
Another one caused a production error. It's becoming apparent to me that
we'll have to switch to `:log` in production so it doesn't break
everything.
