### PR TITLE
Performance: introduce latest_count relation

### DIFF
--- a/app/actions/check/destroy.rb
+++ b/app/actions/check/destroy.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class Check < ApplicationRecord
+  class Destroy
+    include JunkDrawer::Callable
+
+    def call(check)
+      ActiveRecord::Base.transaction do
+        check.update!(latest_count: nil)
+        check.counts.delete_all
+        check.target.delete
+        check.destroy!
+      end
+    end
+  end
+end

--- a/app/actions/check/refresh.rb
+++ b/app/actions/check/refresh.rb
@@ -5,7 +5,10 @@ class Check < ApplicationRecord
     include JunkDrawer::Callable
 
     def call(check)
-      check.counts.create!(value: check.next_count) unless check.manual?
+      unless check.manual?
+        count = check.counts.create!(value: check.next_count)
+        check.update!(latest_count: count)
+      end
       Check::Target::Refresh.call(check.target)
     end
   end

--- a/app/controllers/check_counts_controller.rb
+++ b/app/controllers/check_counts_controller.rb
@@ -11,6 +11,7 @@ class CheckCountsController < ApplicationController
     count = check.counts.new(count_params)
 
     if count.save
+      check.update!(latest_count: count)
       flash[:success] = "Count updated"
       redirect_to(checks_path)
     else

--- a/app/controllers/checks_controller.rb
+++ b/app/controllers/checks_controller.rb
@@ -2,12 +2,10 @@
 
 class ChecksController < ApplicationController
   def index
-    render(
-      locals: {
-        checks: current_user.checks.preload(:counts, :target, :integration),
-        unreached_goal_targets: current_user.targets.unreached_goal,
-      },
-    )
+    checks = current_user.checks.preload(:latest_count, :target, :integration)
+    targets = current_user.targets.unreached_goal
+
+    render(locals: { checks: checks, unreached_goal_targets: targets })
   end
 
   def new; end
@@ -28,7 +26,7 @@ class ChecksController < ApplicationController
   end
 
   def destroy
-    find_check(params[:id]).destroy!
+    Check::Destroy.call(find_check(params[:id]))
 
     flash[:success] = "Check deleted"
     redirect_to(checks_path)

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -3,11 +3,15 @@
 class Check < ApplicationRecord
   belongs_to :user
   belongs_to :integration
-  has_one :target, dependent: :delete, class_name: "Check::Target"
+  belongs_to :latest_count, class_name: "CheckCount"
+  has_one :target, class_name: "Check::Target", dependent: :delete
   has_many :counts, class_name: "CheckCount", dependent: :delete_all
+
   validates :name, presence: true, uniqueness: { scope: :user_id }
   validates :integration_id, :user_id, :target, presence: true
+
   accepts_nested_attributes_for :target, update_only: true
+
   scope(
     :last_counted_before,
     lambda { |timestamp|
@@ -19,6 +23,7 @@ class Check < ApplicationRecord
           .group("checks.id")
     },
   )
+
   delegate :value, to: :target, prefix: true
 
   class << self
@@ -44,6 +49,6 @@ class Check < ApplicationRecord
   end
 
   def last_value
-    counts.last && counts.last.value
+    latest_count && latest_count.value
   end
 end

--- a/db/migrate/20210404221132_add_latest_count_id_to_checks.rb
+++ b/db/migrate/20210404221132_add_latest_count_id_to_checks.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddLatestCountIdToChecks < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_reference :checks,
+                    :latest_count,
+                    foreign_key: { to_table: :check_counts }
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_25_214921) do
+ActiveRecord::Schema.define(version: 2021_04_04_221132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -52,7 +52,9 @@ ActiveRecord::Schema.define(version: 2021_02_25_214921) do
     t.string "type", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "latest_count_id"
     t.index ["integration_id"], name: "index_checks_on_integration_id"
+    t.index ["latest_count_id"], name: "index_checks_on_latest_count_id"
     t.index ["user_id", "name"], name: "index_checks_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_checks_on_user_id"
   end
@@ -80,6 +82,7 @@ ActiveRecord::Schema.define(version: 2021_02_25_214921) do
   add_foreign_key "api_keys", "users"
   add_foreign_key "check_counts", "checks"
   add_foreign_key "check_targets", "checks"
+  add_foreign_key "checks", "check_counts", column: "latest_count_id"
   add_foreign_key "checks", "integrations"
   add_foreign_key "checks", "users"
   add_foreign_key "integrations", "users"

--- a/spec/actions/check/destroy_spec.rb
+++ b/spec/actions/check/destroy_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Check::Destroy do
+  it "deletes the check" do
+    check = create_check
+
+    expect { described_class.call(check) }.to delete_record(check)
+  end
+
+  it "deletes the check when latest_count is set" do
+    check = create_check(counts: [{ value: 6 }])
+
+    expect { described_class.call(check) }.to delete_record(check)
+  end
+
+  it "deletes associated counts" do
+    count = create_count
+
+    expect { described_class.call(count.check) }.to delete_record(count)
+  end
+
+  it "deletes associated target" do
+    target = create_target
+
+    expect { described_class.call(target.check) }.to delete_record(target)
+  end
+
+  it "does not delete other counts" do
+    count = create_count
+
+    expect { described_class.call(create_check) }.not_to delete_record(count)
+  end
+
+  it "does not delete other targets" do
+    target = create_target
+
+    expect { described_class.call(create_check) }.not_to delete_record(target)
+  end
+end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -50,37 +50,37 @@ RSpec.describe Check, type: :model do
   end
 
   describe "#active?" do
-    it "returns true when most recent count > 0" do
+    it "returns true when latest count > 0" do
       check = create_check(counts: [{ value: 1 }])
 
       expect(check.active?).to be(true)
     end
 
-    it "returns false when most recent count == 0" do
+    it "returns false when latest count == 0" do
       check = create_check(counts: [{ value: 0 }])
 
       expect(check.active?).to be(false)
     end
 
-    it "returns false when no counts exist" do
+    it "returns false when no latest count exist" do
       check = create_check
 
       expect(check.active?).to be(false)
     end
 
-    it "returns false when most recent count < target value" do
+    it "returns false when latest count < target value" do
       check = create_check(counts: [{ value: 1 }], target: { value: 2 })
 
       expect(check.active?).to be(false)
     end
 
-    it "returns false when most recent count == target value" do
+    it "returns false when latest count == target value" do
       check = create_check(counts: [{ value: 1 }], target: { value: 1 })
 
       expect(check.active?).to be(false)
     end
 
-    it "returns true when most recent count > target value" do
+    it "returns true when latest count > target value" do
       check = create_check(counts: [{ value: 2 }], target: { value: 1 })
 
       expect(check.active?).to be(true)

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -7,11 +7,10 @@ RSpec.describe ApplicationController, type: :request do
     it "finds the user by session" do
       check = create_check
       login_as(check.user)
-
       params = { check_count: { value: 5 } }
 
       expect { post(check_counts_path(check), params: params) }
-        .to change(check, :last_value).from(nil).to(5)
+        .to change { check.reload.last_value }.from(nil).to(5)
     end
 
     it "finds the user by API key" do
@@ -20,7 +19,7 @@ RSpec.describe ApplicationController, type: :request do
       post_options = { params: { check_count: { value: 5 } }, headers: headers }
 
       expect { post(check_counts_path(check), **post_options) }
-        .to change(check, :last_value).from(nil).to(5)
+        .to change { check.reload.last_value }.from(nil).to(5)
     end
 
     context "when user is not found" do
@@ -29,7 +28,7 @@ RSpec.describe ApplicationController, type: :request do
         params = { check_count: { value: 5 } }
 
         expect { post(check_counts_path(check), params: params) }
-          .not_to change(check, :last_value).from(nil)
+          .not_to change { check.reload.last_value }.from(nil)
       end
 
       it "redirects to new_session_path" do

--- a/spec/requests/check_counts_controller_spec.rb
+++ b/spec/requests/check_counts_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CheckCountsController, type: :request do
         params = { check_count: { value: 5 } }
 
         expect { post(check_counts_path(check), params: params) }
-          .to change(check, :last_value).from(nil).to(5)
+          .to change { check.reload.last_value }.from(nil).to(5)
       end
 
       it "flashes a success message" do

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -33,12 +33,15 @@ module Factories
   end
 
   def create_counts(check, counts)
-    counts.each do |count_params|
-      create_count(count_params.merge(check: check))
-    end
+    created_counts =
+      counts.map do |count_params|
+        create_count(count_params.merge(check: check))
+      end
+    check.update!(latest_count: created_counts.last)
+    created_counts
   end
 
-  def create_count(check:, **params)
+  def create_count(check: create_check, **params)
     check.counts.create!({ value: 0 }.merge(params))
   end
 


### PR DESCRIPTION
Querying for all counts on each request is turning out to be pretty
costly. This instead sets a single `latest_count` on each check that can
be preloaded.
