### PR TITLE
spawn background jobs for each check refresh

### DIFF
--- a/app/actions/check/run_all_outdated.rb
+++ b/app/actions/check/run_all_outdated.rb
@@ -5,7 +5,9 @@ class Check < ApplicationRecord
     include JunkDrawer::Callable
 
     def call
-      stale_checks.find_each(&Check::Refresh)
+      stale_checks.find_each do |check|
+        CallableJob.perform_later("Check::Refresh", check)
+      end
     end
 
     private

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -91,6 +91,8 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  config.active_record.action_on_strict_loading_violation = :log
+
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/spec/actions/check/run_all_outdated_spec.rb
+++ b/spec/actions/check/run_all_outdated_spec.rb
@@ -3,6 +3,12 @@
 require "rails_helper"
 
 RSpec.describe Check::RunAllOutdated do
+  include ActiveJob::TestHelper
+
+  around do |example|
+    perform_enqueued_jobs { example.run }
+  end
+
   it "runs checks that have not been updated in the last five minutes" do
     check = create_check(counts: [{ created_at: 6.minutes.ago }])
     Test::Check.next_values << 5


### PR DESCRIPTION
This will make it so that checks can run in parallel, but also make it
so that if one check raises an error, it doesn't block all of the checks
that follow it.

I'm also switching `strict_loading` to only log violations rather than
raising an error. It can be hard to detect them up front. Later on we
might hook the log into an error tracking service for easier followup.
