### PR TITLE
make sure all manually refreshed targets activate

### DIFF
--- a/app/controllers/targets_controller.rb
+++ b/app/controllers/targets_controller.rb
@@ -2,7 +2,8 @@
 
 class TargetsController < ApplicationController
   def update
-    current_user.targets.unreached_goal.each do |target|
+    unreached_goal_targets = current_user.targets.unreached_goal
+    unreached_goal_targets.preload(check: :latest_count).each do |target|
       Check::Target::Refresh.call(target, force: true)
     end
 

--- a/spec/system/checks/index_spec.rb
+++ b/spec/system/checks/index_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "checks/index", type: :system, js: true do
   end
 
   it "displays a button to refresh targets when no active checks" do
-    check = create_check(counts: [{ value: 3 }], target: { value: 5, delta: 5 })
+    check = create_check(counts: [{ value: 3 }], target: { value: 5, delta: 1 })
     sign_in(check.user)
 
     expect(page).to have_inactive_check(check.name)


### PR DESCRIPTION
This updates the logic for `Check::Target::Refresh` to ensure that when
`force: true` it will decrement the target value until the check will be
active. Right now it is possible to click the refresh button several
times before an active check pops up.
