### PR TITLE
Factories: introduce integration factories

### DIFF
--- a/spec/controllers/github_integrations_controller_spec.rb
+++ b/spec/controllers/github_integrations_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe GithubIntegrationsController do
   describe "#new" do
     it "redirects to the new check page when integration already exists" do
-      integration = create_integration(:github)
+      integration = create(:github_integration)
       login_as(integration.user)
 
       get(:new)

--- a/spec/controllers/trello_integrations_controller_spec.rb
+++ b/spec/controllers/trello_integrations_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe TrelloIntegrationsController do
   describe "#new" do
     it "redirects to the new check page when integration already exists" do
-      integration = create_integration(:trello)
+      integration = create(:trello_integration)
       login_as(integration.user)
 
       get(:new)

--- a/spec/factories/integrations.rb
+++ b/spec/factories/integrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:integration, class: "Test::Integration") do
+    user { default_user }
+  end
+end

--- a/spec/factories/integrations/github_integrations.rb
+++ b/spec/factories/integrations/github_integrations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:github_integration, class: "Integration::Github") do
+    user { default_user }
+    sequence(:access_token) { |n| "foo-token-#{n}" }
+  end
+end

--- a/spec/factories/integrations/manual_integrations.rb
+++ b/spec/factories/integrations/manual_integrations.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:manual_integration, class: "Integration::Manual") do
+    user { default_user }
+  end
+end

--- a/spec/factories/integrations/trello_integrations.rb
+++ b/spec/factories/integrations/trello_integrations.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory(:trello_integration, class: "Integration::Trello") do
+    user { default_user }
+    sequence(:member_token) { |n| "foo-token-#{n}" }
+  end
+end

--- a/spec/models/check/github/user_has_assigned_pull_requests_spec.rb
+++ b/spec/models/check/github/user_has_assigned_pull_requests_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Check::Github::UserHasAssignedPullRequests do
   describe "#next_count" do
     it "returns the count of pull requests" do
       fake_implementation do
-        integration = create_integration(:github)
+        integration = create(:github_integration)
         check = described_class.new(integration: integration)
 
         expect(check.next_count).to eq(2)

--- a/spec/models/check/trello/list_has_cards_spec.rb
+++ b/spec/models/check/trello/list_has_cards_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Check::Trello::ListHasCards do
   describe "#next_count" do
     it "returns the count of cards" do
       fake_implementation do
-        integration = create_integration(:trello)
+        integration = create(:trello_integration)
         check = described_class.new(integration: integration, list_id: "inbox")
 
         expect(check.next_count).to eq(3)

--- a/spec/models/integration_spec.rb
+++ b/spec/models/integration_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe Integration, type: :model do
 
   describe ".github" do
     it "returns GitHub integrations" do
-      integration = create_github_integration
+      integration = create(:github_integration)
 
       expect(described_class.github).to eq([integration])
     end
 
     it "does not return other integrations" do
-      create_trello_integration
+      create(:trello_integration)
 
       expect(described_class.github).to eq([])
     end
@@ -21,13 +21,13 @@ RSpec.describe Integration, type: :model do
 
   describe ".trello" do
     it "returns Trello integrations" do
-      integration = create_trello_integration
+      integration = create(:trello_integration)
 
       expect(described_class.trello).to eq([integration])
     end
 
     it "does not return other integrations" do
-      create_github_integration
+      create(:github_integration)
 
       expect(described_class.trello).to eq([])
     end
@@ -35,13 +35,13 @@ RSpec.describe Integration, type: :model do
 
   describe ".manual" do
     it "returns manual integrations" do
-      integration = create_manual_integration
+      integration = create(:manual_integration)
 
       expect(described_class.manual).to eq([integration])
     end
 
     it "does not return other integrations" do
-      create_github_integration
+      create(:github_integration)
 
       expect(described_class.manual).to eq([])
     end

--- a/spec/requests/manual_checks_controller_spec.rb
+++ b/spec/requests/manual_checks_controller_spec.rb
@@ -5,7 +5,7 @@ require "rails_helper"
 RSpec.describe ManualChecksController, type: :request do
   describe "#new" do
     it "renders the new check page" do
-      integration = create_manual_integration
+      integration = create(:manual_integration)
       login_as(integration.user)
 
       get(new_manual_integration_check_path(integration))
@@ -16,7 +16,7 @@ RSpec.describe ManualChecksController, type: :request do
 
   describe "#create" do
     it "creates a new check" do
-      integration = create_manual_integration
+      integration = create(:manual_integration)
       login_as(integration.user)
 
       path = manual_integration_checks_path(integration)
@@ -25,7 +25,7 @@ RSpec.describe ManualChecksController, type: :request do
     end
 
     it "refreshes the check" do
-      integration = create_manual_integration
+      integration = create(:manual_integration)
       login_as(integration.user)
 
       params = { check: { name: "a new check" } }
@@ -35,7 +35,7 @@ RSpec.describe ManualChecksController, type: :request do
     end
 
     it "redirects to checks/index" do
-      integration = create_manual_integration
+      integration = create(:manual_integration)
       login_as(integration.user)
 
       params = { check: { name: "a new check" } }

--- a/spec/requests/manual_integrations_controller_spec.rb
+++ b/spec/requests/manual_integrations_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ManualIntegrationsController, type: :request do
     end
 
     it "does not create a manual integration when the user already has one" do
-      integration = create_manual_integration
+      integration = create(:manual_integration)
       user = integration.user
       login_as(user)
 
@@ -22,7 +22,7 @@ RSpec.describe ManualIntegrationsController, type: :request do
     end
 
     it "redirects to the new check page for the integration" do
-      integration = create_manual_integration
+      integration = create(:manual_integration)
       login_as(integration.user)
 
       get(new_manual_integration_path)

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -5,9 +5,9 @@ require_relative "factories/requests"
 
 module Factories
   def create_check(counts: [], target: {})
-    integration = create_integration
+    integration = default_integration
     check = Test::Check.create!(
-      name: "some check",
+      name: "some check #{next_id}",
       integration: integration,
       user: integration.user,
       target_attributes: target,
@@ -19,7 +19,7 @@ module Factories
   end
 
   def create_manual_check(counts: [], target: {})
-    integration = create_manual_integration
+    integration = create(:manual_integration)
     check = Check::Manual::AnyCount.create!(
       name: "some check",
       integration: integration,
@@ -52,26 +52,6 @@ module Factories
   def create_target(*traits, **attributes)
     traits.each { |trait| attributes.merge!(TARGET_TRAITS.fetch(trait).call) }
     create_check(target: attributes).target
-  end
-
-  def create_integration(type = :test, user: create(:user))
-    method("create_#{type}_integration").call(user: user)
-  end
-
-  def create_github_integration(user: create(:user))
-    Integration::Github.create!(user: user, access_token: "foo")
-  end
-
-  def create_trello_integration(user: create(:user))
-    Integration::Trello.create!(user: user, member_token: "foo")
-  end
-
-  def create_manual_integration(user: create(:user))
-    Integration::Manual.create!(user: user)
-  end
-
-  def create_test_integration(user: create(:user))
-    Test::Integration.create!(user: user)
   end
 
   def next_id

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,7 +1,39 @@
 # frozen_string_literal: true
 
+module FactoryCache
+  def self.user
+    @user ||= FactoryBot.create(:user)
+  end
+
+  def self.test_integration
+    @test_integration ||= FactoryBot.create(:integration)
+  end
+
+  def self.reset
+    @user = nil
+    @test_integration = nil
+  end
+end
+
 RSpec.configure do |config|
   config.include(FactoryBot::Syntax::Methods)
 
-  config.after { FactoryBot.rewind_sequences }
+  config.after do
+    FactoryBot.rewind_sequences
+    FactoryCache.reset
+  end
+end
+
+module FactoryBot
+  module Syntax
+    module Methods
+      def default_user
+        FactoryCache.user
+      end
+
+      def default_integration
+        FactoryCache.test_integration
+      end
+    end
+  end
 end

--- a/spec/system/check_counts/new_spec.rb
+++ b/spec/system/check_counts/new_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "check_counts/new", type: :system, js: true do
   end
 
   def create_check
-    integration = create_integration(:manual)
+    integration = create(:manual_integration)
     Check::Manual::AnyCount.create!(
       name: "Dishes in sink",
       integration: integration,


### PR DESCRIPTION
And cached `default_user` and `default_integration` so all records will
be associated with the same user/integration by default.
