### PR TITLE
Factories: switch count_values to singular

### DIFF
--- a/spec/actions/check/destroy_spec.rb
+++ b/spec/actions/check/destroy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Check::Destroy do
   end
 
   it "deletes the check when latest_count is set" do
-    check = create(:check, count_values: [6])
+    check = create(:check, count_value: 6)
 
     expect { described_class.call(check) }.to delete_record(check)
   end

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ChecksController, type: :controller do
   end
 
   it "displays Refresh All Targets when targets have unreached goal" do
-    target = create(:target, value: 5, delta: 5, count_values: [3])
+    target = create(:target, value: 5, delta: 5, count_value: 3)
     login_as(target.user)
 
     get(:index)
@@ -23,7 +23,7 @@ RSpec.describe ChecksController, type: :controller do
   end
 
   it "does not display Refresh All Targets when all targets match goal" do
-    check = create(:check, count_values: [0])
+    check = create(:check, count_value: 0)
     login_as(check.user)
 
     get(:index)
@@ -108,7 +108,7 @@ RSpec.describe ChecksController, type: :controller do
     end
 
     it "deletes associated records" do
-      check = create(:check, count_values: [5])
+      check = create(:check, count_value: 5)
       login_as(check.user)
 
       delete(:destroy, params: { id: check.id })

--- a/spec/factories/checks.rb
+++ b/spec/factories/checks.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   factory(:check, class: "Test::Check") do
     transient do
-      count_values { [] }
+      count_value { nil }
       target_delta { 0 }
       target_value { 0 }
     end
@@ -17,12 +17,10 @@ FactoryBot.define do
       # https://github.com/rails/rails/issues/41827
       check.instance_variable_set(:@strict_loading, false)
 
-      counts =
-        evaluator.count_values.map do |value|
-          create(:count, check: check, value: value)
-        end
-
-      check.update!(latest_count: counts.last)
+      if evaluator.count_value
+        count = create(:count, check: check, value: evaluator.count_value)
+        check.update!(latest_count: count)
+      end
     end
   end
 end

--- a/spec/factories/targets.rb
+++ b/spec/factories/targets.rb
@@ -3,10 +3,10 @@
 FactoryBot.define do
   factory(:target, class: "Check::Target") do
     transient do
-      count_values { [] }
+      count_value { nil }
     end
 
-    check { association(:check, target: instance, count_values: count_values) }
+    check { association(:check, target: instance, count_value: count_value) }
 
     trait(:refreshable) do
       next_refresh_at { 1.day.ago }

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -52,13 +52,13 @@ RSpec.describe Check, type: :model do
 
   describe "#active?" do
     it "returns true when latest count > 0" do
-      check = create(:check, count_values: [1])
+      check = create(:check, count_value: 1)
 
       expect(check.active?).to be(true)
     end
 
     it "returns false when latest count == 0" do
-      check = create(:check, count_values: [0])
+      check = create(:check, count_value: 0)
 
       expect(check.active?).to be(false)
     end
@@ -70,19 +70,19 @@ RSpec.describe Check, type: :model do
     end
 
     it "returns false when latest count < target value" do
-      check = create(:check, count_values: [1], target_value: 2)
+      check = create(:check, count_value: 1, target_value: 2)
 
       expect(check.active?).to be(false)
     end
 
     it "returns false when latest count == target value" do
-      check = create(:check, count_values: [1], target_value: 1)
+      check = create(:check, count_value: 1, target_value: 1)
 
       expect(check.active?).to be(false)
     end
 
     it "returns true when latest count > target value" do
-      check = create(:check, count_values: [2], target_value: 1)
+      check = create(:check, count_value: 2, target_value: 1)
 
       expect(check.active?).to be(true)
     end

--- a/spec/system/checks/edit_spec.rb
+++ b/spec/system/checks/edit_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "checks/edit", type: :system, js: true do
   end
 
   it "allows editing a check" do
-    check = create(:check, count_values: [5])
+    check = create(:check, count_value: 5)
     sign_in(check.user)
     expect(page).to have_active_check(check.name)
 
@@ -36,7 +36,7 @@ RSpec.describe "checks/edit", type: :system, js: true do
   end
 
   it "allows setting a moving target on a check" do
-    check = create(:check, count_values: [5])
+    check = create(:check, count_value: 5)
     sign_in(check.user)
 
     Test::Check.next_values << 5 << 5

--- a/spec/system/checks/index_spec.rb
+++ b/spec/system/checks/index_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "checks/index", type: :system, js: true do
   end
 
   it "displays active checks in active section" do
-    check = create(:check, count_values: [5])
+    check = create(:check, count_value: 5)
     sign_in(check.user)
 
     expect(page).to have_active_check(check.name)
@@ -34,7 +34,7 @@ RSpec.describe "checks/index", type: :system, js: true do
   end
 
   it "displays checks that are below target in inactive section" do
-    check = create(:check, count_values: [5], target_value: 6)
+    check = create(:check, count_value: 5, target_value: 6)
     sign_in(check.user)
 
     expect(page).to have_inactive_check(check.name)
@@ -61,7 +61,7 @@ RSpec.describe "checks/index", type: :system, js: true do
   end
 
   it "displays a button to refresh targets when no active checks" do
-    check = create(:check, count_values: [3], target_value: 5, target_delta: 1)
+    check = create(:check, count_value: 3, target_value: 5, target_delta: 1)
     sign_in(check.user)
 
     expect(page).to have_inactive_check(check.name)


### PR DESCRIPTION
It is never used to create more than one count, so probably isn't
necessary to have it be plural.
