### PR TITLE
Unnest count_refresh model

### DIFF
--- a/app/controllers/check_counts_controller.rb
+++ b/app/controllers/check_counts_controller.rb
@@ -4,7 +4,7 @@ class CheckCountsController < ApplicationController
   def new
     check = current_user.checks.preload(:counts).find(params[:check_id])
 
-    render(locals: { check: check, count: CheckCount.new })
+    render(locals: { check: check, count: Count.new })
   end
 
   def create
@@ -27,6 +27,6 @@ class CheckCountsController < ApplicationController
   end
 
   def count_params
-    params.require(:check_count).permit(:value)
+    params.require(:count).permit(:value)
   end
 end

--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -3,9 +3,9 @@
 class Check < ApplicationRecord
   belongs_to :user
   belongs_to :integration
-  belongs_to :latest_count, class_name: "CheckCount"
+  belongs_to :latest_count, class_name: "Count"
   has_one :target, dependent: :delete
-  has_many :counts, class_name: "CheckCount", dependent: :delete_all
+  has_many :counts, dependent: :delete_all
 
   validates :name, presence: true, uniqueness: { scope: :user_id }
   validates :integration_id, :user_id, :target, presence: true
@@ -17,7 +17,7 @@ class Check < ApplicationRecord
     lambda { |timestamp|
       left_joins(:counts)
           .having(
-            "MAX(check_counts.created_at) < ? OR COUNT(check_counts) = 0",
+            "MAX(counts.created_at) < ? OR COUNT(counts) = 0",
             timestamp,
           )
           .group("checks.id")

--- a/app/models/count.rb
+++ b/app/models/count.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CheckCount < ApplicationRecord
+class Count < ApplicationRecord
   belongs_to :check
   validates :check_id, :value, presence: true
 end

--- a/db/migrate/20210502195742_rename_check_counts.rb
+++ b/db/migrate/20210502195742_rename_check_counts.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RenameCheckCounts < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured { rename_table :check_counts, :counts }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_02_194321) do
+ActiveRecord::Schema.define(version: 2021_05_02_195742) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,14 +23,6 @@ ActiveRecord::Schema.define(version: 2021_05_02_194321) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_api_keys_on_user_id"
     t.index ["value"], name: "index_api_keys_on_value", unique: true
-  end
-
-  create_table "check_counts", force: :cascade do |t|
-    t.bigint "check_id", null: false
-    t.bigint "value", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["check_id"], name: "index_check_counts_on_check_id"
   end
 
   create_table "checks", force: :cascade do |t|
@@ -46,6 +38,14 @@ ActiveRecord::Schema.define(version: 2021_05_02_194321) do
     t.index ["latest_count_id"], name: "index_checks_on_latest_count_id"
     t.index ["user_id", "name"], name: "index_checks_on_user_id_and_name", unique: true
     t.index ["user_id"], name: "index_checks_on_user_id"
+  end
+
+  create_table "counts", force: :cascade do |t|
+    t.bigint "check_id", null: false
+    t.bigint "value", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["check_id"], name: "index_counts_on_check_id"
   end
 
   create_table "integrations", force: :cascade do |t|
@@ -80,10 +80,10 @@ ActiveRecord::Schema.define(version: 2021_05_02_194321) do
   end
 
   add_foreign_key "api_keys", "users"
-  add_foreign_key "check_counts", "checks"
-  add_foreign_key "checks", "check_counts", column: "latest_count_id"
+  add_foreign_key "checks", "counts", column: "latest_count_id"
   add_foreign_key "checks", "integrations"
   add_foreign_key "checks", "users"
+  add_foreign_key "counts", "checks"
   add_foreign_key "integrations", "users"
   add_foreign_key "targets", "checks"
 end

--- a/spec/controllers/checks_controller_spec.rb
+++ b/spec/controllers/checks_controller_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe ChecksController, type: :controller do
 
       delete(:destroy, params: { id: check.id })
 
-      expect(CheckCount.where(check_id: check.id)).to be_empty
+      expect(Count.where(check_id: check.id)).to be_empty
     end
 
     it "flashes a success message" do

--- a/spec/factories/counts.rb
+++ b/spec/factories/counts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory(:count, class: "CheckCount") do
+  factory(:count) do
     check
     value { 0 }
   end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -5,17 +5,8 @@ require "rails_helper"
 RSpec.describe Check, type: :model do
   it { is_expected.to belong_to(:integration) }
   it { is_expected.to belong_to(:user) }
-
-  it {
-    is_expected
-      .to have_one(:target).dependent(:delete)
-  }
-
-  it {
-    is_expected
-      .to have_many(:counts).class_name("CheckCount").dependent(:delete_all)
-  }
-
+  it { is_expected.to have_one(:target).dependent(:delete) }
+  it { is_expected.to have_many(:counts).dependent(:delete_all) }
   it { is_expected.to validate_presence_of(:integration_id) }
   it { is_expected.to validate_presence_of(:user_id) }
   it { is_expected.to validate_presence_of(:target) }

--- a/spec/models/count_spec.rb
+++ b/spec/models/count_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe CheckCount, type: :model do
+RSpec.describe Count, type: :model do
   it { is_expected.to validate_presence_of(:check_id) }
   it { is_expected.to validate_presence_of(:value) }
   it { is_expected.to belong_to(:check) }

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ApplicationController, type: :request do
     it "finds the user by session" do
       check = create(:check)
       login_as(default_user)
-      params = { check_count: { value: 5 } }
+      params = { count: { value: 5 } }
 
       expect { post(check_counts_path(check), params: params) }
         .to change { check.reload.last_value }.from(nil).to(5)
@@ -16,7 +16,7 @@ RSpec.describe ApplicationController, type: :request do
     it "finds the user by API key" do
       check = create(:check)
       headers = api_key_headers(create(:api_key))
-      post_options = { params: { check_count: { value: 5 } }, headers: headers }
+      post_options = { params: { count: { value: 5 } }, headers: headers }
 
       expect { post(check_counts_path(check), **post_options) }
         .to change { check.reload.last_value }.from(nil).to(5)
@@ -25,7 +25,7 @@ RSpec.describe ApplicationController, type: :request do
     context "when user is not found" do
       it "does not reach the controller action" do
         check = create(:check)
-        params = { check_count: { value: 5 } }
+        params = { count: { value: 5 } }
 
         expect { post(check_counts_path(check), params: params) }
           .not_to change { check.reload.last_value }.from(nil)
@@ -33,7 +33,7 @@ RSpec.describe ApplicationController, type: :request do
 
       it "redirects to new_session_path" do
         check = create(:check)
-        params = { check_count: { value: 5 } }
+        params = { count: { value: 5 } }
 
         post(check_counts_path(check), params: params)
 

--- a/spec/requests/check_counts_controller_spec.rb
+++ b/spec/requests/check_counts_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe CheckCountsController, type: :request do
       it "creates a new count" do
         check = create(:check)
         login_as(default_user)
-        params = { check_count: { value: 5 } }
+        params = { count: { value: 5 } }
 
         expect { post(check_counts_path(check), params: params) }
           .to change { check.reload.last_value }.from(nil).to(5)
@@ -28,7 +28,7 @@ RSpec.describe CheckCountsController, type: :request do
       it "flashes a success message" do
         check = create(:check)
         login_as(default_user)
-        params = { check_count: { value: 5 } }
+        params = { count: { value: 5 } }
 
         post(check_counts_path(check), params: params)
 
@@ -38,7 +38,7 @@ RSpec.describe CheckCountsController, type: :request do
       it "redirects to checks/index" do
         check = create(:check)
         login_as(default_user)
-        params = { check_count: { value: 5 } }
+        params = { count: { value: 5 } }
 
         post(check_counts_path(check), params: params)
 
@@ -50,7 +50,7 @@ RSpec.describe CheckCountsController, type: :request do
       it "flashes an error message" do
         check = create(:check)
         login_as(default_user)
-        params = { check_count: { value: nil } }
+        params = { count: { value: nil } }
 
         post(check_counts_path(check), params: params)
 
@@ -60,7 +60,7 @@ RSpec.describe CheckCountsController, type: :request do
       it "renders the new count form" do
         check = create(:check)
         login_as(default_user)
-        params = { check_count: { value: nil } }
+        params = { count: { value: nil } }
 
         post(check_counts_path(check), params: params)
 

--- a/spec/system/check_counts/new_spec.rb
+++ b/spec/system/check_counts/new_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe "check_counts/new", type: :system, js: true do
-  def user_creates_check_count
+  def user_creates_count
     click_link("visit manual")
 
     fill_in(:Value, with: 10)
@@ -16,7 +16,7 @@ RSpec.describe "check_counts/new", type: :system, js: true do
     sign_in(default_user)
     expect(page).to have_inactive_check(check.name)
 
-    user_creates_check_count
+    user_creates_count
 
     expect(page).to have_active_check(check.name)
   end


### PR DESCRIPTION
**What**

Renames references from `CheckCount` to `Count`.

**Why**

I don't think there's a great need to have the extra qualifier on the
name here. Currently we only have counts for the `Check` model, and I'm
not aware of any reason we would have any other. So for now I think we
can do without the extra letters.
