### PR TITLE
Bugs: fix issue where target goes negative

### DIFF
--- a/app/actions/target/refresh.rb
+++ b/app/actions/target/refresh.rb
@@ -27,6 +27,7 @@ class Target < ApplicationRecord
       return next_target_value unless last_check_value
       return next_target_value if next_target_value < last_check_value
       return next_target_value if next_target_value == target.goal_value
+      return last_check_value if last_check_value == target.goal_value
 
       last_check_value - 1
     end

--- a/spec/actions/target/refresh_spec.rb
+++ b/spec/actions/target/refresh_spec.rb
@@ -63,5 +63,14 @@ RSpec.describe Target::Refresh do
       expect { described_class.call(target, force: true) }
         .to change_record(target, :value).from(5).to(2)
     end
+
+    it "does not decrement past goal value" do
+      target = create(:target, value: 5, delta: 1)
+      count = create(:count, check: target.check, value: 0)
+      target.check.update!(latest_count: count)
+
+      expect { described_class.call(target, force: true) }
+        .to change_record(target, :value).from(5).to(0)
+    end
   end
 end


### PR DESCRIPTION
The target goes negative when refreshing and the current count already
matches the goal target. For example:

* `check.last_value = 0`
* `target.value = 1`
* `target.goal_value = 0`

Refreshing the target ends up with `target.value = -1` instead of the
expected `0`. This fixes the issue by instead returning the last check
value if it meets the goal.
