### PR TITLE
Performance: stop preloading counts

### DIFF
--- a/app/controllers/check_counts_controller.rb
+++ b/app/controllers/check_counts_controller.rb
@@ -2,7 +2,7 @@
 
 class CheckCountsController < ApplicationController
   def new
-    check = current_user.checks.preload(:counts).find(params[:check_id])
+    check = current_user.checks.find(params[:check_id])
 
     render(locals: { check: check, count: Count.new })
   end
@@ -23,7 +23,7 @@ class CheckCountsController < ApplicationController
   private
 
   def check
-    @check ||= current_user.checks.preload(:counts).find(params[:check_id])
+    @check ||= current_user.checks.find(params[:check_id])
   end
 
   def count_params


### PR DESCRIPTION
This is causing timeouts in production due to the number of counts that
are now in the database. We shouldn't need to preload counts anymore
since we introduced the `last_count` association.
