### PR TITLE
Specs: fix some testing issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,6 +56,7 @@ Style/MethodCallWithArgsParentheses:
     - p
     - puts
     - raise
+    - require
     - require_relative
     - to
     - warn

--- a/spec/models/check/github/user_has_assigned_pull_requests_spec.rb
+++ b/spec/models/check/github/user_has_assigned_pull_requests_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 RSpec.describe Check::Github::UserHasAssignedPullRequests do
   def fake_implementation
+    require Rails.root.join("spec/support/fake_api/github/implementation")
     existing_implementation = Integration::Github.implementation
     Integration::Github.implementation = FakeApi::Github::Implementation
 

--- a/spec/models/check/trello/list_has_cards_spec.rb
+++ b/spec/models/check/trello/list_has_cards_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 RSpec.describe Check::Trello::ListHasCards do
   def fake_implementation
+    require Rails.root.join("spec/support/fake_api/trello/implementation")
+
     existing_implementation = Integration::Trello.implementation
     Integration::Trello.implementation = FakeApi::Trello::Implementation
 

--- a/spec/support/fake_api/github/implementation.rb
+++ b/spec/support/fake_api/github/implementation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../modules"
+
 class FakeApi::Github::Implementation
   class << self
     attr_writer :endpoint_url

--- a/spec/support/fake_api/modules.rb
+++ b/spec/support/fake_api/modules.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module FakeApi
+  module Github
+  end
+
+  module Trello
+  end
+end

--- a/spec/support/fake_api/trello/implementation.rb
+++ b/spec/support/fake_api/trello/implementation.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "../modules"
+
 class FakeApi::Trello::Implementation
   class << self
     attr_writer :endpoint_url

--- a/spec/support/fake_api/trello/server.rb
+++ b/spec/support/fake_api/trello/server.rb
@@ -7,33 +7,41 @@ class FakeApi::Trello::Server < Sinatra::Base
   get("/1/authorize") do
     if params.key?("requestKey")
       <<-HTML
-            <form method="POST" action="/1/token/approve">
-              <input type="submit" class="deny" value="Deny">
-              <input type="submit" name="approve" value="Allow">
-            </form>
+        <form method="POST" action="/1/token/approve">
+          <input type="submit" class="deny" value="Deny">
+          <input type="submit" name="approve" value="Allow">
+        </form>
       HTML
     else
       session["return_url"] = params["returnUrl"]
       <<-HTML
-            <a href='/login'>Log in</a>
+        <a href='/login'>Log in</a>
       HTML
     end
   end
 
   get("/login") do
     <<-HTML
-          <form method="POST">
-            <label for="user">Email or Username</label>
-            <input type="email" name="user" id="user">
-            <label for="password">Password</label>
-            <input type="password" name="password" id="password">
-            <input id="login" type="submit" value="Log in">
-          </form>
+      <form method="POST">
+        <label for="user">Email or Username</label>
+        <input type="email" name="user" id="user">
+        <input id="login" type="submit" value="Log in with Atlassian">
+      </form>
     HTML
   end
 
   post("/login") do
-    redirect("/1/authorize?requestKey=boo")
+    if params.key?("password")
+      redirect("/1/authorize?requestKey=boo")
+    else
+      <<-HTML
+        <form method="POST">
+          <label for="password">Password</label>
+          <input type="password" name="password" id="password">
+          <input id="login" type="submit" value="Log in">
+        </form>
+      HTML
+    end
   end
 
   post("/1/token/approve") do

--- a/spec/support/fake_apis_rails.rb
+++ b/spec/support/fake_apis_rails.rb
@@ -1,15 +1,8 @@
 # frozen_string_literal: true
 
 if fake_apis?
-  module FakeApi
-    module Github
-    end
-
-    module Trello
-    end
-  end
-
   require "capybara_discoball"
+  require_relative "fake_api/modules"
   require_relative "fake_api/github/implementation"
   require_relative "fake_api/github/server"
   require_relative "fake_api/trello/implementation"

--- a/spec/system/integrations/trello_integration_spec.rb
+++ b/spec/system/integrations/trello_integration_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe "Trello integration", type: :system, js: true do
     click_link("Authenticate with Trello")
     click_link("Log in")
     fill_in("user", with: trello_params[:email])
+    click_button("Log in with Atlassian")
     fill_in("password", with: trello_params[:password])
     click_button("Log in")
     click_button("Allow")


### PR DESCRIPTION
* Trello changed their login flow, so this updates to that.
* The `FakeApi` modules are not loaded when `FAKE_APIS=false`, but we're
  still trying to use them in a couple of model tests, so this makes
  them work even when faking is disabled.
