### PR TITLE
Rubocop: disable validator cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,7 @@ Style/WordArray: { EnforcedStyle: brackets }
 
 Bundler/GemComment: { Enabled: false }
 Layout/SingleLineBlockChain: { Enabled: false }
+Rails/RedundantPresenceValidationOnBelongsTo: { Enabled: false }
 Rails/SchemaComment: { Enabled: false }
 RSpec/AlignLeftLetBrace: { Enabled: false }
 RSpec/AlignRightLetBrace: { Enabled: false }

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -19,13 +19,6 @@ Bundler/OrderedGems:
 Lint/ConstantResolution:
   Enabled: false
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Rails/RedundantPresenceValidationOnBelongsTo:
-  Exclude:
-    - 'app/models/check.rb'
-    - 'app/models/count.rb'
-
 # Offense count: 7
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.


### PR DESCRIPTION
We disable the implicit validation provided by ActiveRecord to avoid N+1
queries, so we still want to have a validation on ids.
