### PR TITLE
Change the text displayed on the checks page

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -3,3 +3,4 @@ GITHUB_EMAIL=test@notice.zone
 GITHUB_PASSWORD=whocaresthiswon'tbeused
 GITHUB_CLIENT_ID=trash
 GITHUB_CLIENT_SECRET=alsotrash
+LMKW_TRELLO_DEVELOPER_PUBLIC_KEY=trash

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+postgres 10.18
+ruby 3.1.0

--- a/app/views/checks/_list.html.haml
+++ b/app/views/checks/_list.html.haml
@@ -8,11 +8,9 @@
           %span.check-value.target-value= check.target_value
         %h3
           = icon(*check.icon, class: "fa-lg")
-          = check.name
-        %p
           - options = check.manual? ? {} : { target: :_blank, rel: :noreferrer }
           = link_to(check.url, options) do
-            visit #{check.service}
+            = check.name
             %span.fas.fa-external-link-alt
       .card-actions
         - params = { check: { refresh: true } }

--- a/list.md
+++ b/list.md
@@ -1,0 +1,7 @@
+* fix automated tests
+    * automated tests verify whether code works
+    * 
+* fix linters
+* fork repo
+* push up branch
+* make pull request

--- a/spec/system/check_counts/new_spec.rb
+++ b/spec/system/check_counts/new_spec.rb
@@ -3,8 +3,10 @@
 require "rails_helper"
 
 RSpec.describe "check_counts/new", type: :system, js: true do
-  def user_creates_count
-    click_link("visit manual")
+  def user_creates_count(check)
+    # binding.pry
+    click_link(check.name)
+    # click_link("Manual Check 100")
 
     fill_in(:Value, with: 10)
 
@@ -15,6 +17,7 @@ RSpec.describe "check_counts/new", type: :system, js: true do
     check = create(:manual_check)
     sign_in(default_user)
 
-    expect { user_creates_count }.to activate_check(check.name).in(page)
+    expect { user_creates_count(check) }
+      .to activate_check(check.name).in(page)
   end
 end


### PR DESCRIPTION
Rather than a link that says "Visit Trello", we'll instead link the check name,
e.g. "Cards in Inbox".