### PR TITLE
Deps: add faraday-retry gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "rails", "~> 7.0.0"
 
 gem "bcrypt"
 gem "bootsnap", require: false
+gem "faraday-retry", require: false # wanted by octokit
 gem "font-awesome-sass"
 gem "haml-rails"
 gem "junk_drawer"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
       faraday-net_http (~> 2.0)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.1.0)
+    faraday-retry (2.0.0)
+      faraday (~> 2.0)
     ffi (1.15.5)
     font-awesome-sass (6.1.2)
       sassc (~> 2.0)
@@ -431,6 +433,7 @@ DEPENDENCIES
   capybara-screenshot
   dotenv-rails
   factory_bot_rails
+  faraday-retry
   font-awesome-sass
   guard
   guard-haml_lint


### PR DESCRIPTION
Octokit prints a warning when `faraday-retry` isn't available, so this
adds it in to silence the warning.
