### PR TITLE
Trello: rename methods with `fetch_`

### DIFF
--- a/app/api_wrappers/n_trello/client.rb
+++ b/app/api_wrappers/n_trello/client.rb
@@ -27,8 +27,9 @@ class NTrello::Client
     self.member_token = member_token
   end
 
-  def boards
+  def fetch_boards
     response = HTTP.get(open_boards_url)
+
     ::Trello::Board.from_response(response.body.to_s)
   end
 

--- a/app/models/check/trello/list_has_cards.rb
+++ b/app/models/check/trello/list_has_cards.rb
@@ -3,7 +3,7 @@
 class Check::Trello::ListHasCards < Check
   store_accessor :data, :board_id, :list_id
   validates :board_id, :list_id, presence: true
-  delegate :boards, to: :integration
+  delegate :fetch_boards, to: :integration
   delegate :url, to: :board
 
   STEPS = ["board_id", "list_id", "name"].freeze
@@ -25,14 +25,14 @@ class Check::Trello::ListHasCards < Check
   end
 
   def board
-    integration.find_board(board_id)
+    integration.fetch_board(id: board_id)
   end
 
   def cards
-    integration.find_cards(list_id)
+    integration.fetch_cards(list_id:)
   end
 
   def lists
-    integration.find_lists(board_id)
+    integration.fetch_lists(board_id:)
   end
 end

--- a/app/models/integration/trello.rb
+++ b/app/models/integration/trello.rb
@@ -3,7 +3,7 @@
 class Integration::Trello < Integration
   validates :member_token, presence: true
   store_accessor :data, :member_token
-  delegate :boards, to: :client
+  delegate :fetch_boards, to: :client
 
   class_attribute :client_class, default: NTrello::Client
 
@@ -11,19 +11,19 @@ class Integration::Trello < Integration
     client_class.authorize_url(return_url:)
   end
 
-  def find_board(board_id)
-    board = client.find(:board, board_id)
+  def fetch_board(id:)
+    board = client.find(:board, id)
 
     NTrello::Board.new(id: board.id, url: board.url)
   end
 
-  def find_lists(board_id)
+  def fetch_lists(board_id:)
     lists = client.find_many(::Trello::List, "/boards/#{board_id}/lists")
 
     lists.map { |list| NTrello::List.new(id: list.id, name: list.name) }
   end
 
-  def find_cards(list_id)
+  def fetch_cards(list_id:)
     cards = client.find_many(::Trello::Card, "/lists/#{list_id}/cards")
 
     cards.map { |card| NTrello::Card.new(id: card.id, name: card.name) }

--- a/app/views/trello_checks/_board_id.html.haml
+++ b/app/views/trello_checks/_board_id.html.haml
@@ -3,6 +3,6 @@
 - submit_path = new_trello_integration_check_path(trello_integration)
 = form_with(model: check, url: submit_path, method: :get) do |form|
   = form.label(:board_id, "Boards")
-  = form.collection_select(:board_id, check.boards, :id, :name)
+  = form.collection_select(:board_id, check.fetch_boards, :id, :name)
 
   = form.submit("Next")

--- a/spec/api_wrappers/n_trello/client_spec.rb
+++ b/spec/api_wrappers/n_trello/client_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe NTrello::Client do
     end
   end
 
-  describe "#boards" do
+  describe "#fetch_boards" do
     def response(uri:, body:)
       body = String.new(body)
       HTTP::Response.new(status: 200, version: "1.1", uri:, body:)
@@ -29,7 +29,7 @@ RSpec.describe NTrello::Client do
 
       boards_url = "https://api.trello.com/1/members/boo/boards?#{params.to_query}"
       member_url = "https://api.trello.com/1/members/me?#{auth_params.to_query}"
-      expect { client.boards }
+      expect { client.fetch_boards }
         .to invoke(:get).on(HTTP).with(member_url)
         .and_return(response(uri: member_url, body: "{\"username\": \"boo\"}"))
         .and invoke(:get).on(HTTP).with(boards_url)

--- a/spec/support/fake_api/trello/client.rb
+++ b/spec/support/fake_api/trello/client.rb
@@ -36,7 +36,7 @@ class FakeApi::Trello::Client
     end
   end
 
-  def boards
+  def fetch_boards
     FakeApi::Trello::Implementation::Board.all
   end
 


### PR DESCRIPTION
to make it more explicit that these are grabbing resources from a 3rd
party API.
