### PR TITLE
Trello: eliminate `find_many` calls

### DIFF
--- a/spec/api_wrappers/n_trello/client_spec.rb
+++ b/spec/api_wrappers/n_trello/client_spec.rb
@@ -63,10 +63,8 @@ RSpec.describe NTrello::Client do
   describe "#fetch_lists" do
     it "returns lists with the given board id" do
       client = described_class.new(member_token: "blah")
-      path = "/boards/3/lists"
-      lists = [NTrello::List.new(id: 4, name: "list 1")]
-      expect(client)
-        .to receive(:find_many).with(::Trello::List, path).and_return(lists)
+      stub_request(:get, "https://api.trello.com/1/boards/3/lists?key=b151cfc72ed56c15f13296ffbaf96194&token=blah")
+        .to_return(body: [{ id: 4, name: "list 1" }].to_json)
 
       result = client.fetch_lists(board_id: 3)
 
@@ -77,10 +75,8 @@ RSpec.describe NTrello::Client do
   describe "#fetch_cards" do
     it "returns cards with the given list id" do
       client = described_class.new(member_token: "blah")
-      path = "/lists/5/cards"
-      cards = [NTrello::Card.new(id: 6, name: "card 6")]
-      expect(client)
-        .to receive(:find_many).with(::Trello::Card, path).and_return(cards)
+      stub_request(:get, "https://api.trello.com/1/lists/5/cards?key=b151cfc72ed56c15f13296ffbaf96194&token=blah")
+        .to_return(body: [{ id: 6, name: "card 6" }].to_json)
 
       result = client.fetch_cards(list_id: 5)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require "pry-byebug"
 
 require_relative "support/matchers"
 require_relative "support/fake_apis"
+require_relative "support/webmock"
 
 RSpec.configure do |config|
   config.expect_with(:rspec) do |expectations|

--- a/spec/support/fake_api/trello/client.rb
+++ b/spec/support/fake_api/trello/client.rb
@@ -30,28 +30,16 @@ class FakeApi::Trello::Client
     NTrello::Board.new(id: board.id, url: board.url)
   end
 
-  def fetch_lists(board_id:)
-    lists = find_many(::Trello::List, "/boards/#{board_id}/lists")
+  def fetch_lists(**)
+    lists = FakeApi::Trello::Implementation::List.all
 
     lists.map { |list| NTrello::List.new(id: list.id, name: list.name) }
   end
 
-  def fetch_cards(list_id:)
-    cards = find_many(::Trello::Card, "/lists/#{list_id}/cards")
+  def fetch_cards(**)
+    card = NTrello::Card.new(id: 1, name: "some card")
 
-    cards.map { |card| NTrello::Card.new(id: card.id, name: card.name) }
-  end
-
-  def find_many(klass, _path)
-    case klass.name
-    when "Trello::Card"
-      card = NTrello::Card.new(id: 1, name: "some card")
-      [card, card, card]
-    when "Trello::List"
-      FakeApi::Trello::Implementation::List.all
-    else
-      raise ArgumentError, "unknown klass \"#{klass}\""
-    end
+    [card, card, card]
   end
 
   def fetch_boards

--- a/spec/support/fake_apis.rb
+++ b/spec/support/fake_apis.rb
@@ -6,5 +6,3 @@ module FakeApis
     ENV["FAKE_APIS"] != "false"
   end
 end
-
-require_relative "webmock" if FakeApis.enabled?

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -2,7 +2,11 @@
 
 require "webmock/rspec"
 
-WebMock.disable_net_connect!(
-  allow_localhost: true,
-  allow: [/geckodriver/, /chromedriver/],
-)
+if FakeApis.enabled?
+  WebMock.disable_net_connect!(
+    allow_localhost: true,
+    allow: [/geckodriver/, /chromedriver/],
+  )
+else
+  WebMock.allow_net_connect!
+end


### PR DESCRIPTION
Make the request ourselves. Also loads `WebMock` even when we're not
faking APIs so that we can stub requests in unit tests.

This code is in sore need of some refactoring, so we'll do that once the
`ruby-trello` gem is fully removed.
