### PR TITLE
remove refresh meta tag

### DIFF
--- a/app/views/checks/index.html.haml
+++ b/app/views/checks/index.html.haml
@@ -1,6 +1,3 @@
-- content_for(:header_meta) do
-  %meta{ "http-equiv": "refresh", content: "300" }
-
 .header
   = link_to("+ New Check", new_check_path, class: "btn-primary new-check-btn")
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,6 @@
     = csrf_meta_tags
     = csp_meta_tag
     %meta{ name: "viewport", content: "width=device-width, initial-scale=1.0" }/
-    = content_for(:header_meta)
 
     = stylesheet_link_tag("application",
                           media: "all",


### PR DESCRIPTION
Refreshing seems to be causing Trello throttling for some reason. There
are a couple of fixes that need to be made. For one, we shouldn't be
hitting Trello for each check every time we refresh the page. For
another, we should be refreshing checks only when they change, probably
via Turbo. We should also use Trello webhooks to trigger updates when
something changes, rather than manually polling frequently.
