### PR TITLE
Trello: rename NTrello module

### DIFF
--- a/app/api_wrappers/trello.rb
+++ b/app/api_wrappers/trello.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-module NTrello
+module Trello
 end

--- a/app/api_wrappers/trello/board.rb
+++ b/app/api_wrappers/trello/board.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NTrello::Board
+class Trello::Board
   attr_accessor :id, :name, :url
 
   def initialize(id:, name:, url:)

--- a/app/api_wrappers/trello/card.rb
+++ b/app/api_wrappers/trello/card.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NTrello::List
+class Trello::Card
   attr_accessor :id, :name
 
   def initialize(id:, name:)

--- a/app/api_wrappers/trello/client.rb
+++ b/app/api_wrappers/trello/client.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NTrello::Client
+class Trello::Client
   attr_accessor :member_token
 
   def self.developer_public_key
@@ -30,7 +30,7 @@ class NTrello::Client
     response = HTTP.get(board_url)
     board = JSON.parse(response.body, symbolize_names: true)
 
-    NTrello::Board.new(**board.slice(:id, :name, :url))
+    Trello::Board.new(**board.slice(:id, :name, :url))
   end
 
   def fetch_lists(board_id:)
@@ -39,7 +39,7 @@ class NTrello::Client
     response = HTTP.get(lists_url)
     lists = JSON.parse(response.body, symbolize_names: true)
 
-    lists.map { |list| NTrello::List.new(**list.slice(:id, :name)) }
+    lists.map { |list| Trello::List.new(**list.slice(:id, :name)) }
   end
 
   def fetch_cards(list_id:)
@@ -48,14 +48,14 @@ class NTrello::Client
     response = HTTP.get(cards_url)
     cards = JSON.parse(response.body, symbolize_names: true)
 
-    cards.map { |card| NTrello::Card.new(**card.slice(:id, :name)) }
+    cards.map { |card| Trello::Card.new(**card.slice(:id, :name)) }
   end
 
   def fetch_boards
     response = HTTP.get(open_boards_url)
     boards = JSON.parse(response.body, symbolize_names: true)
 
-    boards.map { |board| NTrello::Board.new(**board.slice(:id, :name, :url)) }
+    boards.map { |board| Trello::Board.new(**board.slice(:id, :name, :url)) }
   end
 
   private

--- a/app/api_wrappers/trello/list.rb
+++ b/app/api_wrappers/trello/list.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class NTrello::Card
+class Trello::List
   attr_accessor :id, :name
 
   def initialize(id:, name:)

--- a/app/models/integration/trello.rb
+++ b/app/models/integration/trello.rb
@@ -5,7 +5,7 @@ class Integration::Trello < Integration
   store_accessor :data, :member_token
   delegate :fetch_board, :fetch_boards, :fetch_lists, :fetch_cards, to: :client
 
-  class_attribute :client_class, default: NTrello::Client
+  class_attribute :client_class, default: ::Trello::Client
 
   def self.authorize_url(return_url:)
     client_class.authorize_url(return_url:)

--- a/spec/api_wrappers/trello/client_spec.rb
+++ b/spec/api_wrappers/trello/client_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe NTrello::Client do
+RSpec.describe Trello::Client do
   delegate :developer_public_key, to: :described_class
 
   def auth_params

--- a/spec/support/fake_api/trello/client.rb
+++ b/spec/support/fake_api/trello/client.rb
@@ -27,17 +27,17 @@ class FakeApi::Trello::Client
   def fetch_board(id:)
     board = find(:board, id)
 
-    NTrello::Board.new(id: board.id, name: board.name, url: board.url)
+    Trello::Board.new(id: board.id, name: board.name, url: board.url)
   end
 
   def fetch_lists(**)
     lists = FakeApi::Trello::Implementation::List.all
 
-    lists.map { |list| NTrello::List.new(id: list.id, name: list.name) }
+    lists.map { |list| Trello::List.new(id: list.id, name: list.name) }
   end
 
   def fetch_cards(**)
-    card = NTrello::Card.new(id: 1, name: "some card")
+    card = Trello::Card.new(id: 1, name: "some card")
 
     [card, card, card]
   end


### PR DESCRIPTION
Now that we're no longer using the Trello gem.
