### PR TITLE
Deps: pin nokogiri version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "font-awesome-sass"
 gem "haml-rails"
 gem "http"
 gem "junk_drawer"
+gem "nokogiri", "~> 1.14.0.rc1" # for Ruby 3.2
 gem "octokit"
 gem "pg"
 gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.13.10)
+    nokogiri (1.14.0.rc1)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -427,6 +427,7 @@ DEPENDENCIES
   http
   junk_drawer
   listen
+  nokogiri (~> 1.14.0.rc1)
   octokit
   pg
   pry-byebug


### PR DESCRIPTION
The current release version does not work with Ruby 3.2.
